### PR TITLE
Refactor mobile PDF viewer visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Privacy API support for reading state and reward records.
 - `thirdpartylibs.xml` entries for PDF.js, Plyr and StPageFlip.
 - Documentation for architecture, installation, security, development and manual testing.
+- Mobile PDF viewport stabilizer for iOS/Safari rendering edge cases.
+- Dedicated visual refinement stylesheet for Drive Resource activity presentation.
 
 ### Changed
 
@@ -34,6 +36,8 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Activity form now supports Google Drive and local protected PDF sources.
 - Completion can be calculated from PDF page progress.
 - README updated for protected local PDF and ebook workflows.
+- PDF viewer mobile layout now uses larger touch targets, safer viewport units and reduced chrome spacing.
+- PDF visual presentation was refactored into focused stylesheets for maintainability.
 
 ### Security
 

--- a/amd/src/pdfmobile.js
+++ b/amd/src/pdfmobile.js
@@ -17,6 +17,7 @@ define([], function() {
     const CANVAS_SELECTOR = '.mod-videoplayer-pdfjs-canvas';
     const STABILIZE_DELAY = 120;
     const MAX_ATTEMPTS = 20;
+    const VIEWPORT_GUTTER = 12;
 
     /**
      * Whether current viewport should use the mobile stabilizer.
@@ -25,6 +26,48 @@ define([], function() {
      */
     const isMobile = function() {
         return window.matchMedia(MOBILE_QUERY).matches;
+    };
+
+    /**
+     * Return a reliable canvas aspect ratio based on the rendered bitmap.
+     *
+     * @param {HTMLCanvasElement} canvas Rendered PDF canvas.
+     * @returns {number}
+     */
+    const getCanvasRatio = function(canvas) {
+        if (!canvas || !canvas.width || !canvas.height) {
+            return 1;
+        }
+
+        return canvas.width / canvas.height;
+    };
+
+    /**
+     * Force mobile PDF pages to open in a safe fit-page mode.
+     *
+     * @param {HTMLElement} wrap Canvas wrapper.
+     * @param {HTMLCanvasElement} canvas Rendered PDF canvas.
+     * @returns {void}
+     */
+    const applySafeFitPage = function(wrap, canvas) {
+        const ratio = getCanvasRatio(canvas);
+        const availableWidth = Math.max(wrap.clientWidth - VIEWPORT_GUTTER, 260);
+        const availableHeight = Math.max(wrap.clientHeight - VIEWPORT_GUTTER, 320);
+        let targetWidth = availableWidth;
+        let targetHeight = targetWidth / ratio;
+
+        if (targetHeight > availableHeight) {
+            targetHeight = availableHeight;
+            targetWidth = targetHeight * ratio;
+        }
+
+        canvas.style.width = Math.floor(targetWidth) + 'px';
+        canvas.style.height = Math.floor(targetHeight) + 'px';
+        canvas.style.maxWidth = '100%';
+        canvas.style.maxHeight = 'none';
+        canvas.style.marginLeft = 'auto';
+        canvas.style.marginRight = 'auto';
+        canvas.style.display = 'block';
     };
 
     /**
@@ -44,28 +87,10 @@ define([], function() {
             return;
         }
 
-        const availableWidth = Math.max(wrap.clientWidth - 8, 280);
-        const inlineWidth = parseFloat(canvas.style.width || '0');
-        const inlineHeight = parseFloat(canvas.style.height || '0');
+        applySafeFitPage(wrap, canvas);
 
-        if (!inlineWidth || !inlineHeight) {
-            return;
-        }
-
-        if (inlineWidth > availableWidth) {
-            const ratio = availableWidth / inlineWidth;
-            canvas.style.width = Math.floor(availableWidth) + 'px';
-            canvas.style.height = Math.floor(inlineHeight * ratio) + 'px';
-        }
-
-        canvas.style.maxWidth = '100%';
-        canvas.style.marginLeft = 'auto';
-        canvas.style.marginRight = 'auto';
-        canvas.style.display = 'block';
-
-        if (wrap.scrollLeft !== 0) {
-            wrap.scrollLeft = 0;
-        }
+        wrap.scrollLeft = 0;
+        wrap.scrollTop = 0;
     };
 
     /**

--- a/amd/src/pdfmobile.js
+++ b/amd/src/pdfmobile.js
@@ -1,0 +1,114 @@
+// This file is part of Moodle - http://moodle.org/
+
+/**
+ * Mobile viewport stabilizer for the protected PDF.js viewer.
+ *
+ * This module fixes iOS/Safari layout edge cases where the PDF canvas can
+ * render wider than the visible viewport or start with a horizontal offset.
+ *
+ * @module     mod_videoplayer/pdfmobile
+ * @copyright  2026 Jose Erasmo Moreno Salgado - Elearning Cloud
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+define([], function() {
+    const MOBILE_QUERY = '(max-width: 767.98px)';
+    const VIEWER_SELECTOR = '.mod-videoplayer-pdfjs-viewer';
+    const WRAP_SELECTOR = '.mod-videoplayer-pdfjs-canvas-wrap';
+    const CANVAS_SELECTOR = '.mod-videoplayer-pdfjs-canvas';
+    const STABILIZE_DELAY = 120;
+    const MAX_ATTEMPTS = 20;
+
+    /**
+     * Whether current viewport should use the mobile stabilizer.
+     *
+     * @returns {boolean}
+     */
+    const isMobile = function() {
+        return window.matchMedia(MOBILE_QUERY).matches;
+    };
+
+    /**
+     * Apply safe display constraints to one viewer.
+     *
+     * @param {HTMLElement} viewer Viewer node.
+     * @returns {void}
+     */
+    const stabilizeViewer = function(viewer) {
+        if (!isMobile() || !viewer) {
+            return;
+        }
+
+        const wrap = viewer.querySelector(WRAP_SELECTOR);
+        const canvas = viewer.querySelector(CANVAS_SELECTOR);
+        if (!wrap || !canvas || !canvas.width || !canvas.height) {
+            return;
+        }
+
+        const availableWidth = Math.max(wrap.clientWidth - 8, 280);
+        const inlineWidth = parseFloat(canvas.style.width || '0');
+        const inlineHeight = parseFloat(canvas.style.height || '0');
+
+        if (!inlineWidth || !inlineHeight) {
+            return;
+        }
+
+        if (inlineWidth > availableWidth) {
+            const ratio = availableWidth / inlineWidth;
+            canvas.style.width = Math.floor(availableWidth) + 'px';
+            canvas.style.height = Math.floor(inlineHeight * ratio) + 'px';
+        }
+
+        canvas.style.maxWidth = '100%';
+        canvas.style.marginLeft = 'auto';
+        canvas.style.marginRight = 'auto';
+        canvas.style.display = 'block';
+
+        if (wrap.scrollLeft !== 0) {
+            wrap.scrollLeft = 0;
+        }
+    };
+
+    /**
+     * Stabilize all PDF viewers after PDF.js has rendered.
+     *
+     * @param {number} attempt Current retry attempt.
+     * @returns {void}
+     */
+    const stabilizeAll = function(attempt) {
+        if (!isMobile()) {
+            return;
+        }
+
+        const viewers = Array.prototype.slice.call(document.querySelectorAll(VIEWER_SELECTOR));
+        viewers.forEach(stabilizeViewer);
+
+        if (attempt < MAX_ATTEMPTS) {
+            window.setTimeout(function() {
+                stabilizeAll(attempt + 1);
+            }, STABILIZE_DELAY);
+        }
+    };
+
+    /**
+     * Initialise mobile PDF viewport stabilisation.
+     *
+     * @returns {void}
+     */
+    const init = function() {
+        stabilizeAll(0);
+
+        window.addEventListener('resize', function() {
+            stabilizeAll(0);
+        });
+
+        window.addEventListener('orientationchange', function() {
+            window.setTimeout(function() {
+                stabilizeAll(0);
+            }, 250);
+        });
+    };
+
+    return {
+        init: init
+    };
+});

--- a/amd/src/pdfviewer.js
+++ b/amd/src/pdfviewer.js
@@ -1,7 +1,7 @@
 // This file is part of Moodle - http://moodle.org/
 
 /**
- * Protected PDF.js ebook viewer for Drive Resource.
+ * Protected PDF.js viewer for Drive Resource.
  *
  * @module     mod_videoplayer/pdfviewer
  * @copyright  2026 Jose Erasmo Moreno Salgado - Elearning Cloud
@@ -11,6 +11,10 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
     const PDFJS_URL = M.cfg.wwwroot + '/mod/videoplayer/thirdpartylibs/pdfjs/pdf.min.mjs';
     const PDFJS_WORKER_URL = M.cfg.wwwroot + '/mod/videoplayer/thirdpartylibs/pdfjs/pdf.worker.min.mjs';
     const SAVE_INTERVAL = 10000;
+    const MIN_ZOOM = 0.75;
+    const MAX_ZOOM = 2.75;
+    const ZOOM_STEP = 0.15;
+    const MOBILE_BREAKPOINT = 768;
     let pdfjsPromise = null;
 
     const loadPdfJs = function() {
@@ -33,6 +37,14 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         event.preventDefault();
         event.stopPropagation();
         return false;
+    };
+
+    const clamp = function(value, min, max) {
+        return Math.max(min, Math.min(max, value));
+    };
+
+    const isMobileViewport = function() {
+        return window.matchMedia('(max-width: ' + (MOBILE_BREAKPOINT - 1) + 'px)').matches;
     };
 
     const showError = function(root, error) {
@@ -89,8 +101,12 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         const previous = root.querySelector('[data-action="previous-page"]');
         const next = root.querySelector('[data-action="next-page"]');
         const fullscreen = root.querySelector('[data-action="fullscreen"]');
+        const zoomIn = root.querySelector('[data-action="zoom-in"]');
+        const zoomOut = root.querySelector('[data-action="zoom-out"]');
+        const fitScreen = root.querySelector('[data-action="fit-screen"]');
         const currentPageNode = root.querySelector('[data-region="current-page"]');
         const totalPagesNode = root.querySelector('[data-region="total-pages"]');
+        const zoomLevelNode = root.querySelector('[data-region="zoom-level"]');
         const loading = root.querySelector('[data-region="pdfjs-loading"]');
         const wrap = root.querySelector('.mod-videoplayer-pdfjs-canvas-wrap');
         const container = root.closest('.mod-videoplayer-container') || document;
@@ -103,6 +119,8 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         }
 
         hardenViewer(root, canvas);
+        root.classList.toggle('is-mobile-viewer', isMobileViewport());
+
         const context = canvas.getContext('2d');
         let pdfDocument = null;
         let pageNumber = Math.max(1, parseInt(root.getAttribute('data-initial-page'), 10) || 1);
@@ -113,6 +131,11 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         let activeSeconds = 0;
         let lastTick = Date.now();
         let completed = false;
+        let zoomFactor = 1;
+        let autoFit = true;
+        let touchStartX = 0;
+        let touchStartY = 0;
+        let touchMoved = false;
 
         const isFullscreen = function() {
             return document.fullscreenElement || root.classList.contains('is-fallback-fullscreen');
@@ -123,6 +146,14 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
                 return 0;
             }
             return Math.min(100, Math.round((pageNumber / pdfDocument.numPages) * 10000) / 100);
+        };
+
+        const updateZoomStatus = function(baseScale, appliedScale) {
+            if (!zoomLevelNode || !baseScale) {
+                return;
+            }
+            const relativeZoom = Math.round((appliedScale / baseScale) * 100);
+            zoomLevelNode.textContent = relativeZoom + '%';
         };
 
         const saveProgress = function(force) {
@@ -174,6 +205,15 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             if (next) {
                 next.disabled = pageNumber >= pdfDocument.numPages;
             }
+            if (zoomOut) {
+                zoomOut.disabled = zoomFactor <= MIN_ZOOM;
+            }
+            if (zoomIn) {
+                zoomIn.disabled = zoomFactor >= MAX_ZOOM;
+            }
+            if (fitScreen) {
+                fitScreen.classList.toggle('is-active', autoFit && zoomFactor === 1);
+            }
             if (currentPageNode) {
                 currentPageNode.textContent = String(pageNumber);
             }
@@ -189,19 +229,45 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             pdfDocument.getPage(num).catch(function() {});
         };
 
+        const restoreScrollPosition = function(oldWidth, oldHeight, oldScrollLeft, oldScrollTop) {
+            if (!wrap) {
+                return;
+            }
+
+            if (firstRender || autoFit) {
+                wrap.scrollLeft = 0;
+                wrap.scrollTop = 0;
+                return;
+            }
+
+            const widthRatio = oldWidth > 0 ? wrap.scrollWidth / oldWidth : 1;
+            const heightRatio = oldHeight > 0 ? wrap.scrollHeight / oldHeight : 1;
+            wrap.scrollLeft = oldScrollLeft * widthRatio;
+            wrap.scrollTop = oldScrollTop * heightRatio;
+        };
+
         const renderPage = function(num) {
+            const oldScrollWidth = wrap ? wrap.scrollWidth : 0;
+            const oldScrollHeight = wrap ? wrap.scrollHeight : 0;
+            const oldScrollLeft = wrap ? wrap.scrollLeft : 0;
+            const oldScrollTop = wrap ? wrap.scrollTop : 0;
+
             rendering = true;
             canvas.classList.add('is-rendering');
             if (firstRender) {
                 hide(loading, false);
             }
             pdfDocument.getPage(num).then(function(page) {
-                const availableWidth = wrap ? Math.max(wrap.clientWidth - 24, 320) : 900;
-                const availableHeight = wrap ? Math.max(wrap.clientHeight - 24, 360) : 900;
+                const horizontalPadding = isMobileViewport() ? 10 : 24;
+                const verticalPadding = isMobileViewport() ? 10 : 24;
+                const availableWidth = wrap ? Math.max(wrap.clientWidth - horizontalPadding, 280) : 900;
+                const availableHeight = wrap ? Math.max(wrap.clientHeight - verticalPadding, 320) : 900;
                 const base = page.getViewport({scale: 1});
                 const fitWidth = availableWidth / base.width;
                 const fitHeight = availableHeight / base.height;
-                const cssScale = isFullscreen() ? Math.min(fitWidth, fitHeight) : fitWidth;
+                const baseScale = isFullscreen() ? Math.min(fitWidth, fitHeight) : fitWidth;
+                const appliedZoom = autoFit ? 1 : zoomFactor;
+                const cssScale = clamp(baseScale * appliedZoom, baseScale * MIN_ZOOM, baseScale * MAX_ZOOM);
                 const viewport = page.getViewport({scale: cssScale});
                 const outputScale = isFullscreen() ? Math.min(window.devicePixelRatio || 1, 3) : Math.min(window.devicePixelRatio || 1, 2.25);
                 canvas.width = Math.floor(viewport.width * outputScale);
@@ -209,6 +275,7 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
                 canvas.style.width = Math.floor(viewport.width) + 'px';
                 canvas.style.height = Math.floor(viewport.height) + 'px';
                 context.setTransform(1, 0, 0, 1, 0, 0);
+                updateZoomStatus(baseScale, cssScale);
                 return page.render({
                     canvasContext: context,
                     viewport: viewport,
@@ -216,6 +283,7 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
                 }).promise;
             }).then(function() {
                 rendering = false;
+                restoreScrollPosition(oldScrollWidth, oldScrollHeight, oldScrollLeft, oldScrollTop);
                 firstRender = false;
                 hide(loading, true);
                 canvas.classList.remove('is-rendering');
@@ -248,6 +316,17 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
                 return;
             }
             pageNumber = Math.max(1, Math.min(pdfDocument.numPages, num));
+            autoFit = true;
+            zoomFactor = 1;
+            queue(pageNumber);
+        };
+
+        const zoomTo = function(value) {
+            if (!pdfDocument) {
+                return;
+            }
+            zoomFactor = clamp(value, MIN_ZOOM, MAX_ZOOM);
+            autoFit = zoomFactor === 1;
             queue(pageNumber);
         };
 
@@ -260,6 +339,62 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             next.addEventListener('click', function() {
                 go(pageNumber + 1);
             });
+        }
+        if (zoomIn) {
+            zoomIn.addEventListener('click', function() {
+                zoomTo(zoomFactor + ZOOM_STEP);
+            });
+        }
+        if (zoomOut) {
+            zoomOut.addEventListener('click', function() {
+                zoomTo(zoomFactor - ZOOM_STEP);
+            });
+        }
+        if (fitScreen) {
+            fitScreen.addEventListener('click', function() {
+                zoomFactor = 1;
+                autoFit = true;
+                queue(pageNumber);
+            });
+        }
+        if (wrap) {
+            wrap.addEventListener('touchstart', function(event) {
+                if (!event.touches || event.touches.length !== 1) {
+                    return;
+                }
+                touchMoved = false;
+                touchStartX = event.touches[0].clientX;
+                touchStartY = event.touches[0].clientY;
+            }, {passive: true});
+
+            wrap.addEventListener('touchmove', function(event) {
+                if (!event.touches || event.touches.length !== 1) {
+                    return;
+                }
+                const dx = event.touches[0].clientX - touchStartX;
+                const dy = event.touches[0].clientY - touchStartY;
+                touchMoved = Math.abs(dx) > 18 || Math.abs(dy) > 18;
+            }, {passive: true});
+
+            wrap.addEventListener('touchend', function(event) {
+                if (!touchMoved || !pdfDocument) {
+                    return;
+                }
+                const changed = event.changedTouches && event.changedTouches[0];
+                if (!changed) {
+                    return;
+                }
+                const dx = changed.clientX - touchStartX;
+                const dy = changed.clientY - touchStartY;
+                if (Math.abs(dx) < 70 || Math.abs(dx) < Math.abs(dy) * 1.35) {
+                    return;
+                }
+                if (dx < 0) {
+                    go(pageNumber + 1);
+                } else {
+                    go(pageNumber - 1);
+                }
+            }, {passive: true});
         }
         if (fullscreen) {
             fullscreen.addEventListener('click', function() {
@@ -288,7 +423,10 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         }
 
         window.addEventListener('resize', function() {
+            root.classList.toggle('is-mobile-viewer', isMobileViewport());
             if (pdfDocument) {
+                autoFit = true;
+                zoomFactor = 1;
                 queue(pageNumber);
             }
         });

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -83,6 +83,32 @@ Moodle events + Completion API
 
 Use `amd/src/pdfviewer.js` for one-page protected PDF rendering.
 
+### Mobile PDF stabilizer
+
+Use `amd/src/pdfmobile.js` for mobile viewport corrections that should remain independent from the PDF.js rendering pipeline.
+
+This module is intentionally small and should only handle mobile layout stabilization, including:
+
+- iOS/Safari canvas overflow correction.
+- initial horizontal scroll correction.
+- viewport re-stabilization after orientation changes.
+- late PDF.js canvas rendering edge cases.
+
+Do not move authorization, file access, progress calculation or PDF.js document loading into this module.
+
+### Visual stylesheets
+
+Presentation CSS is split by responsibility:
+
+```text
+styles.css                         Base plugin styles loaded by Moodle.
+styles_pdf_overlay.css             PDF.js overlay and canvas behavior.
+styles_pdf_mobile.css              Mobile PDF-specific viewport rules.
+styles_visual_refinements.css      Product-level visual polish for Drive Resource.
+```
+
+Keep mobile fixes isolated from the generic styles whenever possible. This reduces regression risk for desktop Moodle themes.
+
 ### Ebook viewer
 
 Use `amd/src/ebookviewer.js` for ebook rendering.
@@ -168,3 +194,4 @@ Before release:
 - Moodle debug developer mode clean.
 - PHP warnings clean.
 - JavaScript console clean.
+- mobile PDF viewer tested on iOS Safari, Android Chrome and Moodle app WebView.

--- a/styles_pdf_mobile.css
+++ b/styles_pdf_mobile.css
@@ -101,9 +101,9 @@
     .mod-videoplayer-pdfjs-canvas-wrap {
         min-height: 80svh !important;
         height: 80svh !important;
-        padding: .15rem !important;
+        padding: .25rem !important;
         align-items: flex-start !important;
-        justify-content: flex-start !important;
+        justify-content: center !important;
         overflow: auto !important;
         overscroll-behavior: contain;
         -webkit-overflow-scrolling: touch;
@@ -113,10 +113,11 @@
     }
 
     .mod-videoplayer-pdfjs-canvas {
-        max-width: none !important;
+        display: block !important;
+        max-width: 100% !important;
         width: auto !important;
         height: auto !important;
-        margin: 0 !important;
+        margin: 0 auto !important;
         border-radius: 8px !important;
         box-shadow: 0 8px 18px rgba(15, 23, 42, .18) !important;
     }
@@ -217,7 +218,7 @@
     .mod-videoplayer-pdfjs-viewer:fullscreen .mod-videoplayer-pdfjs-canvas-wrap {
         min-height: 100svh !important;
         height: 100svh !important;
-        padding: calc(env(safe-area-inset-top, 0px) + .45rem) .15rem calc(env(safe-area-inset-bottom, 0px) + .45rem) !important;
+        padding: calc(env(safe-area-inset-top, 0px) + .45rem) .25rem calc(env(safe-area-inset-bottom, 0px) + .45rem) !important;
     }
 }
 

--- a/styles_pdf_mobile.css
+++ b/styles_pdf_mobile.css
@@ -58,8 +58,8 @@
     }
 
     .mod-videoplayer-pdfjs {
-        margin-left: calc(var(--bs-gutter-x, 1.5rem) * -.25);
-        margin-right: calc(var(--bs-gutter-x, 1.5rem) * -.25);
+        margin-left: calc(var(--bs-gutter-x, 1.5rem) * -.35);
+        margin-right: calc(var(--bs-gutter-x, 1.5rem) * -.35);
     }
 
     .mod-videoplayer-pdfjs .mod-videoplayer-meta {
@@ -99,23 +99,24 @@
     }
 
     .mod-videoplayer-pdfjs-canvas-wrap {
-        min-height: 78svh !important;
-        height: 78svh !important;
-        padding: .25rem !important;
+        min-height: 80svh !important;
+        height: 80svh !important;
+        padding: .15rem !important;
         align-items: flex-start !important;
-        justify-content: center !important;
+        justify-content: flex-start !important;
         overflow: auto !important;
         overscroll-behavior: contain;
         -webkit-overflow-scrolling: touch;
         touch-action: pan-x pan-y;
         background: #f1f5f9 !important;
+        scrollbar-width: thin;
     }
 
     .mod-videoplayer-pdfjs-canvas {
         max-width: none !important;
         width: auto !important;
         height: auto !important;
-        margin: 0 auto !important;
+        margin: 0 !important;
         border-radius: 8px !important;
         box-shadow: 0 8px 18px rgba(15, 23, 42, .18) !important;
     }
@@ -148,7 +149,7 @@
 
     .mod-videoplayer-pdfjs-control-prev,
     .mod-videoplayer-pdfjs-control-next {
-        top: calc(39svh + .25rem) !important;
+        top: calc(40svh + .25rem) !important;
         font-size: 2rem !important;
     }
 
@@ -216,7 +217,7 @@
     .mod-videoplayer-pdfjs-viewer:fullscreen .mod-videoplayer-pdfjs-canvas-wrap {
         min-height: 100svh !important;
         height: 100svh !important;
-        padding: calc(env(safe-area-inset-top, 0px) + .45rem) .25rem calc(env(safe-area-inset-bottom, 0px) + .45rem) !important;
+        padding: calc(env(safe-area-inset-top, 0px) + .45rem) .15rem calc(env(safe-area-inset-bottom, 0px) + .45rem) !important;
     }
 }
 

--- a/styles_pdf_mobile.css
+++ b/styles_pdf_mobile.css
@@ -1,0 +1,245 @@
+/*
+ * Mobile-first overrides for the protected PDF.js viewer.
+ *
+ * These rules intentionally live in a dedicated stylesheet so the mobile
+ * reading experience can evolve without increasing risk in the generic
+ * activity stylesheet.
+ */
+
+.mod-videoplayer-pdfjs {
+    max-width: 100%;
+}
+
+.mod-videoplayer-pdfjs-viewer {
+    isolation: isolate;
+}
+
+.mod-videoplayer-pdfjs-control.is-active {
+    background: #ffffff;
+    outline: 2px solid rgba(6, 182, 201, .35);
+}
+
+.mod-videoplayer-pdfjs-control-zoomout {
+    top: .75rem;
+    left: .75rem;
+}
+
+.mod-videoplayer-pdfjs-control-zoomin {
+    top: .75rem;
+    left: 4rem;
+}
+
+.mod-videoplayer-pdfjs-control-fit {
+    top: .75rem;
+    right: 4rem;
+    font-size: 1.05rem;
+}
+
+.mod-videoplayer-pdfjs-viewer:fullscreen {
+    width: 100vw !important;
+    height: 100vh !important;
+    max-width: none !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: #0f172a !important;
+}
+
+.mod-videoplayer-pdfjs-viewer:fullscreen .mod-videoplayer-pdfjs-canvas-wrap {
+    height: 100vh !important;
+    min-height: 100vh !important;
+    padding: .75rem !important;
+    background: #0f172a !important;
+}
+
+@media (max-width: 767.98px) {
+    body.path-mod-videoplayer .activity-header,
+    body.path-mod-videoplayer #page-header {
+        margin-bottom: .35rem;
+    }
+
+    .mod-videoplayer-pdfjs {
+        margin-left: calc(var(--bs-gutter-x, 1.5rem) * -.25);
+        margin-right: calc(var(--bs-gutter-x, 1.5rem) * -.25);
+    }
+
+    .mod-videoplayer-pdfjs .mod-videoplayer-meta {
+        gap: .35rem;
+        margin-bottom: .45rem !important;
+        padding: 0 .15rem;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+        scrollbar-width: none;
+    }
+
+    .mod-videoplayer-pdfjs .mod-videoplayer-meta::-webkit-scrollbar {
+        display: none;
+    }
+
+    .mod-videoplayer-pdfjs .mod-videoplayer-meta-item {
+        flex: 0 0 auto;
+        padding: .25rem .55rem;
+        font-size: .78rem;
+        line-height: 1.2;
+        white-space: nowrap;
+        background: rgba(255, 255, 255, .92);
+    }
+
+    .mod-videoplayer-resume {
+        margin-bottom: .45rem;
+        padding: .5rem .65rem;
+        font-size: .85rem;
+    }
+
+    .mod-videoplayer-pdfjs-viewer {
+        width: 100%;
+        max-width: none;
+        margin: 0;
+        border-radius: 14px;
+        box-shadow: 0 8px 18px rgba(15, 23, 42, .10);
+    }
+
+    .mod-videoplayer-pdfjs-canvas-wrap {
+        min-height: 78svh !important;
+        height: 78svh !important;
+        padding: .25rem !important;
+        align-items: flex-start !important;
+        justify-content: center !important;
+        overflow: auto !important;
+        overscroll-behavior: contain;
+        -webkit-overflow-scrolling: touch;
+        touch-action: pan-x pan-y;
+        background: #f1f5f9 !important;
+    }
+
+    .mod-videoplayer-pdfjs-canvas {
+        max-width: none !important;
+        width: auto !important;
+        height: auto !important;
+        margin: 0 auto !important;
+        border-radius: 8px !important;
+        box-shadow: 0 8px 18px rgba(15, 23, 42, .18) !important;
+    }
+
+    .mod-videoplayer-pdfjs-overlay {
+        position: sticky !important;
+        top: .25rem !important;
+        left: 0 !important;
+        right: 0 !important;
+        height: 0 !important;
+        z-index: 25 !important;
+        pointer-events: none;
+    }
+
+    .mod-videoplayer-pdfjs-control,
+    .mod-videoplayer-pdfjs-control-fullscreen {
+        width: 46px !important;
+        height: 46px !important;
+        min-width: 46px !important;
+        min-height: 46px !important;
+        padding: 0 !important;
+        border-radius: 999px !important;
+        font-size: 1.25rem !important;
+        background: rgba(255, 255, 255, .94) !important;
+        color: #0f172a !important;
+        box-shadow: 0 10px 26px rgba(15, 23, 42, .18) !important;
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+    }
+
+    .mod-videoplayer-pdfjs-control-prev,
+    .mod-videoplayer-pdfjs-control-next {
+        top: calc(39svh + .25rem) !important;
+        font-size: 2rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-prev {
+        left: .35rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-next {
+        right: .35rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-zoomout,
+    .mod-videoplayer-pdfjs-control-zoomin,
+    .mod-videoplayer-pdfjs-control-fit,
+    .mod-videoplayer-pdfjs-control-fullscreen {
+        top: .45rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-zoomout {
+        left: .45rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-zoomin {
+        left: 3.55rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-fit {
+        right: 3.55rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-fullscreen {
+        right: .45rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-page-status {
+        top: .45rem !important;
+        left: 50% !important;
+        min-width: 64px !important;
+        padding: .45rem .65rem !important;
+        font-size: .9rem !important;
+        line-height: 1.1;
+        background: rgba(255, 255, 255, .96) !important;
+        box-shadow: 0 10px 26px rgba(15, 23, 42, .14) !important;
+    }
+
+    .mod-videoplayer-pdfjs-zoom-status {
+        display: none !important;
+    }
+
+    .mod-videoplayer-watermark {
+        font-size: clamp(1.15rem, 7vw, 2.25rem);
+        padding: 1rem;
+    }
+
+    .is-fallback-fullscreen.mod-videoplayer-pdfjs-viewer,
+    .mod-videoplayer-pdfjs-viewer:fullscreen {
+        inset: 0 !important;
+        width: 100vw !important;
+        height: 100svh !important;
+        max-width: none !important;
+        border-radius: 0 !important;
+    }
+
+    .is-fallback-fullscreen .mod-videoplayer-pdfjs-canvas-wrap,
+    .mod-videoplayer-pdfjs-viewer:fullscreen .mod-videoplayer-pdfjs-canvas-wrap {
+        min-height: 100svh !important;
+        height: 100svh !important;
+        padding: calc(env(safe-area-inset-top, 0px) + .45rem) .25rem calc(env(safe-area-inset-bottom, 0px) + .45rem) !important;
+    }
+}
+
+@media (max-width: 420px) {
+    .mod-videoplayer-pdfjs-control,
+    .mod-videoplayer-pdfjs-control-fullscreen {
+        width: 44px !important;
+        height: 44px !important;
+        min-width: 44px !important;
+        min-height: 44px !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-zoomin {
+        left: 3.35rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-control-fit {
+        right: 3.35rem !important;
+    }
+
+    .mod-videoplayer-pdfjs-page-status {
+        min-width: 58px !important;
+        padding: .42rem .55rem !important;
+        font-size: .84rem !important;
+    }
+}

--- a/styles_visual_refinements.css
+++ b/styles_visual_refinements.css
@@ -1,0 +1,109 @@
+/*
+ * Drive Resource visual refinements.
+ *
+ * This stylesheet keeps presentation polish separated from the base Moodle
+ * activity styles and from PDF-specific mobile fixes.
+ */
+
+.mod-videoplayer-container {
+    --drive-resource-accent: var(--bs-primary, var(--primary, #06b6c9));
+    --drive-resource-accent-strong: #0891b2;
+    --drive-resource-surface: rgba(255, 255, 255, .96);
+    --drive-resource-border: rgba(100, 116, 139, .20);
+    --drive-resource-muted: #64748b;
+    --drive-resource-ink: #0f172a;
+}
+
+.mod-videoplayer-meta {
+    margin-bottom: .8rem;
+}
+
+.mod-videoplayer-meta-item {
+    color: var(--drive-resource-muted);
+    border-color: var(--drive-resource-border);
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, .96), rgba(248, 250, 252, .92));
+    box-shadow: 0 5px 14px rgba(15, 23, 42, .045);
+}
+
+.mod-videoplayer-pdfjs-viewer,
+.mod-videoplayer-frame-wrapper,
+.mod-videoplayer-native-frame {
+    border-color: var(--drive-resource-border);
+}
+
+.mod-videoplayer-pdfjs-viewer {
+    background:
+        radial-gradient(circle at 10% 0%, rgba(6, 182, 201, .10), transparent 20rem),
+        radial-gradient(circle at 90% 0%, rgba(59, 130, 246, .08), transparent 22rem),
+        linear-gradient(135deg, #f8fafc, #eef2f7);
+}
+
+.mod-videoplayer-pdfjs-canvas-wrap {
+    background:
+        linear-gradient(180deg, rgba(241, 245, 249, .92), rgba(226, 232, 240, .92));
+}
+
+.mod-videoplayer-pdfjs-control {
+    font-weight: 800;
+}
+
+.mod-videoplayer-pdfjs-control-fullscreen,
+.mod-videoplayer-pdfjs-control-fit.is-active {
+    color: #ffffff !important;
+    background: var(--drive-resource-accent) !important;
+}
+
+.mod-videoplayer-pdfjs-control-fullscreen:hover,
+.mod-videoplayer-pdfjs-control-fullscreen:focus,
+.mod-videoplayer-pdfjs-control-fit.is-active:hover,
+.mod-videoplayer-pdfjs-control-fit.is-active:focus {
+    background: var(--drive-resource-accent-strong) !important;
+}
+
+.mod-videoplayer-pdfjs-page-status {
+    border: 1px solid rgba(255, 255, 255, .62);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.mod-videoplayer-native-frame {
+    border: 1px solid rgba(15, 23, 42, .12);
+}
+
+.mod-videoplayer-native .plyr {
+    overflow: hidden;
+}
+
+.mod-videoplayer-frame-wrapper {
+    border: 1px solid rgba(15, 23, 42, .12);
+    background:
+        linear-gradient(135deg, #0f172a, #111827);
+}
+
+@media (max-width: 767.98px) {
+    .mod-videoplayer-container {
+        --mod-videoplayer-radius: .9rem;
+    }
+
+    .mod-videoplayer-meta {
+        margin-bottom: .55rem;
+    }
+
+    .mod-videoplayer-meta-item {
+        box-shadow: none;
+    }
+
+    .mod-videoplayer-pdfjs-viewer {
+        border-color: rgba(100, 116, 139, .24);
+        background: #f8fafc;
+    }
+
+    .mod-videoplayer-pdfjs-canvas-wrap {
+        background: #f8fafc !important;
+    }
+
+    .mod-videoplayer-pdfjs-control {
+        border: 1px solid rgba(148, 163, 184, .22) !important;
+    }
+}

--- a/view.php
+++ b/view.php
@@ -19,6 +19,7 @@ $PAGE->set_url('/mod/videoplayer/view.php', ['id' => $cm->id]);
 $PAGE->set_title(format_string($videoplayer->name));
 $PAGE->set_heading(format_string($course->fullname));
 $PAGE->set_context($context);
+$PAGE->requires->css('/mod/videoplayer/styles_visual_refinements.css');
 
 $event = \mod_videoplayer\event\course_module_viewed::create([
     'objectid' => $videoplayer->id,

--- a/view.php
+++ b/view.php
@@ -101,6 +101,7 @@ if (!isguestuser()) {
 
 if ($type === 'pdf') {
     $PAGE->requires->css('/mod/videoplayer/styles_pdf_overlay.css');
+    $PAGE->requires->css('/mod/videoplayer/styles_pdf_mobile.css');
     $PAGE->requires->js_call_amd('mod_videoplayer/pdfviewer', 'init');
 } else if ($type === 'video') {
     $PAGE->requires->css('/mod/videoplayer/thirdpartylibs/plyr/plyr.css');

--- a/view.php
+++ b/view.php
@@ -103,6 +103,7 @@ if ($type === 'pdf') {
     $PAGE->requires->css('/mod/videoplayer/styles_pdf_overlay.css');
     $PAGE->requires->css('/mod/videoplayer/styles_pdf_mobile.css');
     $PAGE->requires->js_call_amd('mod_videoplayer/pdfviewer', 'init');
+    $PAGE->requires->js_call_amd('mod_videoplayer/pdfmobile', 'init');
 } else if ($type === 'video') {
     $PAGE->requires->css('/mod/videoplayer/thirdpartylibs/plyr/plyr.css');
     $PAGE->requires->js_call_amd('mod_videoplayer/plyr', 'init');


### PR DESCRIPTION
## Summary

This PR refactors and improves the Drive Resource viewer presentation, with a strong focus on the protected PDF.js mobile experience.

## Changes

- Adds `styles_visual_refinements.css` to keep product-level UI polish separate from base Moodle activity CSS.
- Adds `styles_pdf_mobile.css` for mobile-specific PDF viewport and touch target rules.
- Adds `amd/src/pdfmobile.js` as a small mobile stabilizer for iOS/Safari canvas overflow and initial horizontal offset issues.
- Loads the new visual stylesheet, mobile PDF stylesheet and mobile stabilizer from `view.php`.
- Improves PDF controls for mobile with larger touch targets and safer viewport units.
- Updates `CHANGELOG.md` and `docs/developer-guide.md` to document the visual refactor.

## Validation required

- Purge Moodle caches after deployment.
- Run `grunt amd` before production packaging if AMD build artifacts are required.
- Test protected PDFs on:
  - iOS Safari.
  - Android Chrome.
  - Moodle app WebView.
  - Desktop Chrome/Firefox.

## Notes

The proxy/security flow in `protected.php` is intentionally untouched in this PR.