### PR TITLE
Add protected responsive book viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Documentation for architecture, installation, security, development and manual testing.
 - Mobile PDF viewport stabilizer for iOS/Safari rendering edge cases.
 - Dedicated visual refinement stylesheet for Drive Resource activity presentation.
+- Protected responsive book viewer with desktop two-page spread and mobile one-page reading mode.
 
 ### Changed
 
@@ -38,6 +39,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - README updated for protected local PDF and ebook workflows.
 - PDF viewer mobile layout now uses larger touch targets, safer viewport units and reduced chrome spacing.
 - PDF visual presentation was refactored into focused stylesheets for maintainability.
+- PDF resources now render through the protected book viewer by default.
 
 ### Security
 

--- a/amd/src/bookviewer.js
+++ b/amd/src/bookviewer.js
@@ -1,0 +1,390 @@
+// This file is part of Moodle - http://moodle.org/
+
+/**
+ * Protected responsive book viewer for Drive Resource.
+ *
+ * Desktop renders a two-page spread. Mobile renders one page with a light
+ * flip-style transition. The PDF source remains protected through Moodle.
+ *
+ * @module     mod_videoplayer/bookviewer
+ * @copyright  2026 Jose Erasmo Moreno Salgado - Elearning Cloud
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
+    const PDFJS_URL = M.cfg.wwwroot + '/mod/videoplayer/thirdpartylibs/pdfjs/pdf.min.mjs';
+    const PDFJS_WORKER_URL = M.cfg.wwwroot + '/mod/videoplayer/thirdpartylibs/pdfjs/pdf.worker.min.mjs';
+    const SAVE_INTERVAL = 10000;
+    const MOBILE_QUERY = '(max-width: 767.98px)';
+    let pdfjsPromise = null;
+
+    const loadPdfJs = function() {
+        if (!pdfjsPromise) {
+            pdfjsPromise = import(PDFJS_URL).then(function(pdfjsLib) {
+                pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_URL;
+                return pdfjsLib;
+            });
+        }
+        return pdfjsPromise;
+    };
+
+    const isMobile = function() {
+        return window.matchMedia(MOBILE_QUERY).matches;
+    };
+
+    const hide = function(node, value) {
+        if (node) {
+            node.hidden = value;
+        }
+    };
+
+    const block = function(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        return false;
+    };
+
+    const hardenViewer = function(root) {
+        if (root.getAttribute('data-disable-context-menu') !== '1') {
+            return;
+        }
+        ['contextmenu', 'dragstart', 'copy', 'cut', 'paste', 'selectstart'].forEach(function(name) {
+            root.addEventListener(name, block, true);
+        });
+        root.addEventListener('keydown', function(event) {
+            const key = (event.key || '').toLowerCase();
+            if ((event.ctrlKey || event.metaKey) && ['s', 'p', 'c', 'a'].indexOf(key) !== -1) {
+                block(event);
+            }
+        }, true);
+    };
+
+    const initViewer = function(root, pdfjsLib) {
+        const pdfUrl = root.getAttribute('data-pdf-url');
+        const cmid = parseInt(root.getAttribute('data-cmid'), 10) || 0;
+        const initialPage = Math.max(1, parseInt(root.getAttribute('data-initial-page'), 10) || 1);
+        const reader = root.closest('.mod-videoplayer-book-reader') || root;
+        const stage = root.querySelector('[data-region="book-stage"]');
+        const pagesRegion = root.querySelector('[data-region="book-pages"]');
+        const previous = root.querySelector('[data-action="previous-page"]');
+        const next = root.querySelector('[data-action="next-page"]');
+        const fullscreen = root.querySelector('[data-action="fullscreen"]');
+        const currentPageNode = root.querySelector('[data-region="current-page"]');
+        const totalPagesNode = root.querySelector('[data-region="total-pages"]');
+        const loading = root.querySelector('[data-region="book-loading"]');
+        const error = root.querySelector('[data-region="book-error"]');
+        const progressNode = (root.closest('.mod-videoplayer-container') || document).querySelector('[data-region="book-progress"]');
+
+        if (!pdfUrl || !stage || !pagesRegion) {
+            hide(error, false);
+            return;
+        }
+
+        hardenViewer(root);
+
+        let pdfDocument = null;
+        let pageNumber = initialPage;
+        let rendering = false;
+        let pendingPage = null;
+        let lastSave = 0;
+        let activeSeconds = 0;
+        let lastTick = Date.now();
+        let completed = false;
+        let touchStartX = 0;
+        let touchStartY = 0;
+        let touchMoved = false;
+
+        const getSpreadStart = function(num) {
+            if (isMobile()) {
+                return num;
+            }
+            return num <= 1 ? 1 : (num % 2 === 0 ? num : num - 1);
+        };
+
+        const getVisiblePages = function() {
+            if (!pdfDocument) {
+                return [];
+            }
+            if (isMobile()) {
+                return [pageNumber];
+            }
+            const start = getSpreadStart(pageNumber);
+            const pages = [start];
+            if (start + 1 <= pdfDocument.numPages) {
+                pages.push(start + 1);
+            }
+            return pages;
+        };
+
+        const updateStatus = function() {
+            if (!pdfDocument) {
+                return;
+            }
+            if (currentPageNode) {
+                const pages = getVisiblePages();
+                currentPageNode.textContent = pages.length > 1 ? pages[0] + '-' + pages[1] : String(pageNumber);
+            }
+            if (totalPagesNode) {
+                totalPagesNode.textContent = String(pdfDocument.numPages);
+            }
+            if (previous) {
+                previous.disabled = pageNumber <= 1;
+            }
+            if (next) {
+                next.disabled = pageNumber >= pdfDocument.numPages;
+            }
+        };
+
+        const completionPercent = function() {
+            if (!pdfDocument || !pdfDocument.numPages) {
+                return 0;
+            }
+            return Math.min(100, Math.round((pageNumber / pdfDocument.numPages) * 10000) / 100);
+        };
+
+        const saveProgress = function(force) {
+            if (!cmid || !pdfDocument) {
+                return Promise.resolve();
+            }
+            const now = Date.now();
+            if (!force && now - lastSave < SAVE_INTERVAL) {
+                return Promise.resolve();
+            }
+            activeSeconds += Math.max(0, Math.round((now - lastTick) / 1000));
+            lastTick = now;
+            lastSave = now;
+            const percent = completionPercent();
+            completed = completed || percent >= 100;
+
+            return Ajax.call([{
+                methodname: 'mod_videoplayer_save_progress',
+                args: {
+                    cmid: cmid,
+                    progress: activeSeconds,
+                    completed: completed,
+                    completionpercentage: percent,
+                    lastpage: pageNumber,
+                    totalpages: pdfDocument.numPages,
+                    timespent: activeSeconds
+                }
+            }])[0].then(function(response) {
+                if (response) {
+                    completed = Boolean(response.completed);
+                    if (progressNode) {
+                        progressNode.textContent = response.completionpercentage + '%';
+                    }
+                }
+                return response;
+            }).catch(Notification.exception);
+        };
+
+        const getPageWidth = function() {
+            const stageWidth = Math.max(stage.clientWidth - (isMobile() ? 24 : 128), 280);
+            return isMobile() ? Math.min(stageWidth, 720) : Math.min(stageWidth / 2, 560);
+        };
+
+        const renderPageCanvas = function(pageIndex) {
+            return pdfDocument.getPage(pageIndex).then(function(page) {
+                const base = page.getViewport({scale: 1});
+                const targetWidth = getPageWidth();
+                const scale = Math.min(Math.max(targetWidth / base.width, 0.5), 2.2);
+                const viewport = page.getViewport({scale: scale});
+                const outputScale = Math.min(window.devicePixelRatio || 1, 2);
+                const canvas = document.createElement('canvas');
+                const context = canvas.getContext('2d');
+
+                canvas.width = Math.floor(viewport.width * outputScale);
+                canvas.height = Math.floor(viewport.height * outputScale);
+                canvas.style.width = Math.floor(viewport.width) + 'px';
+                canvas.style.height = Math.floor(viewport.height) + 'px';
+                canvas.setAttribute('draggable', 'false');
+
+                return page.render({
+                    canvasContext: context,
+                    viewport: viewport,
+                    transform: outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null
+                }).promise.then(function() {
+                    return canvas;
+                });
+            });
+        };
+
+        const renderSpread = function() {
+            if (!pdfDocument || rendering) {
+                return;
+            }
+            rendering = true;
+            pagesRegion.classList.add('is-turning');
+            hide(loading, false);
+            pagesRegion.innerHTML = '';
+
+            const visiblePages = getVisiblePages();
+            const renderers = visiblePages.map(function(num) {
+                return renderPageCanvas(num).then(function(canvas) {
+                    const pageNode = document.createElement('div');
+                    pageNode.className = 'mod-videoplayer-book-page';
+                    pageNode.setAttribute('data-page-number', String(num));
+                    if (isMobile()) {
+                        pageNode.classList.add('is-mobile-turning');
+                    }
+                    pageNode.appendChild(canvas);
+                    pagesRegion.appendChild(pageNode);
+                });
+            });
+
+            if (!isMobile() && visiblePages.length === 1) {
+                const empty = document.createElement('div');
+                empty.className = 'mod-videoplayer-book-page is-empty';
+                pagesRegion.appendChild(empty);
+            }
+
+            Promise.all(renderers).then(function() {
+                rendering = false;
+                hide(loading, true);
+                pagesRegion.classList.remove('is-turning');
+                updateStatus();
+                saveProgress(false);
+                if (pendingPage !== null) {
+                    const queued = pendingPage;
+                    pendingPage = null;
+                    goToPage(queued);
+                }
+            }).catch(function(err) {
+                rendering = false;
+                hide(loading, true);
+                hide(error, false);
+                Notification.exception(err);
+            });
+        };
+
+        const goToPage = function(num) {
+            if (!pdfDocument) {
+                return;
+            }
+            const step = isMobile() ? 1 : 2;
+            const safe = Math.max(1, Math.min(pdfDocument.numPages, num));
+            pageNumber = isMobile() ? safe : getSpreadStart(safe);
+            if (rendering) {
+                pendingPage = pageNumber;
+                return;
+            }
+            renderSpread();
+            saveProgress(false);
+        };
+
+        if (previous) {
+            previous.addEventListener('click', function() {
+                goToPage(pageNumber - (isMobile() ? 1 : 2));
+            });
+        }
+        if (next) {
+            next.addEventListener('click', function() {
+                goToPage(pageNumber + (isMobile() ? 1 : 2));
+            });
+        }
+        if (fullscreen) {
+            fullscreen.addEventListener('click', function() {
+                if (document.fullscreenElement) {
+                    document.exitFullscreen();
+                    return;
+                }
+                if (reader.requestFullscreen) {
+                    reader.requestFullscreen().catch(function() {
+                        reader.classList.add('is-fallback-fullscreen');
+                    });
+                } else {
+                    reader.classList.add('is-fallback-fullscreen');
+                }
+            });
+            document.addEventListener('fullscreenchange', function() {
+                if (!document.fullscreenElement) {
+                    reader.classList.remove('is-fallback-fullscreen');
+                }
+                window.setTimeout(renderSpread, 160);
+            });
+        }
+
+        stage.addEventListener('touchstart', function(event) {
+            if (!event.touches || event.touches.length !== 1) {
+                return;
+            }
+            touchMoved = false;
+            touchStartX = event.touches[0].clientX;
+            touchStartY = event.touches[0].clientY;
+        }, {passive: true});
+
+        stage.addEventListener('touchmove', function(event) {
+            if (!event.touches || event.touches.length !== 1) {
+                return;
+            }
+            const dx = event.touches[0].clientX - touchStartX;
+            const dy = event.touches[0].clientY - touchStartY;
+            touchMoved = Math.abs(dx) > 20 || Math.abs(dy) > 20;
+        }, {passive: true});
+
+        stage.addEventListener('touchend', function(event) {
+            if (!touchMoved || !pdfDocument) {
+                return;
+            }
+            const changed = event.changedTouches && event.changedTouches[0];
+            if (!changed) {
+                return;
+            }
+            const dx = changed.clientX - touchStartX;
+            const dy = changed.clientY - touchStartY;
+            if (Math.abs(dx) < 60 || Math.abs(dx) < Math.abs(dy) * 1.35) {
+                return;
+            }
+            goToPage(pageNumber + (dx < 0 ? 1 : -1));
+        }, {passive: true});
+
+        window.addEventListener('resize', function() {
+            window.setTimeout(renderSpread, 120);
+        });
+        window.addEventListener('orientationchange', function() {
+            window.setTimeout(renderSpread, 280);
+        });
+        window.addEventListener('beforeunload', function() {
+            saveProgress(true);
+        });
+        document.addEventListener('visibilitychange', function() {
+            if (document.hidden) {
+                saveProgress(true);
+            } else {
+                lastTick = Date.now();
+            }
+        });
+
+        hide(loading, false);
+        pdfjsLib.getDocument({url: pdfUrl, withCredentials: true, rangeChunkSize: 262144}).promise.then(function(pdf) {
+            pdfDocument = pdf;
+            pageNumber = Math.min(initialPage, pdfDocument.numPages);
+            if (!isMobile()) {
+                pageNumber = getSpreadStart(pageNumber);
+            }
+            updateStatus();
+            renderSpread();
+        }).catch(function(err) {
+            hide(loading, true);
+            hide(error, false);
+            Notification.exception(err);
+        });
+    };
+
+    const init = function() {
+        const roots = Array.prototype.slice.call(document.querySelectorAll('.mod-videoplayer-book-reader'));
+        if (!roots.length) {
+            return;
+        }
+        loadPdfJs().then(function(pdfjsLib) {
+            roots.forEach(function(root) {
+                initViewer(root, pdfjsLib);
+            });
+        }).catch(function(err) {
+            Notification.exception(err);
+        });
+    };
+
+    return {
+        init: init
+    };
+});

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -60,7 +60,7 @@ The external API should validate parameters, context, login and capability, then
 ## Progress save flow
 
 ```text
-ebookviewer.js / pdfviewer.js
+bookviewer.js / ebookviewer.js / pdfviewer.js
 ↓
 core/ajax
 ↓
@@ -79,9 +79,24 @@ Moodle events + Completion API
 
 ## Viewer development
 
+### Protected book viewer
+
+Use `amd/src/bookviewer.js` with `templates/book.mustache` for the default protected PDF book experience.
+
+Expected behavior:
+
+- Desktop renders a two-page spread to behave like a real book.
+- Mobile renders one page at a time, similar to FlipHTML5-style reading.
+- Fullscreen keeps previous/next buttons inside the PDF stage.
+- Navigation works through buttons and mobile swipe gestures.
+- Progress is saved by last visible page.
+- PDF content is still delivered only through `protected.php`.
+
+Do not expose raw Google Drive URLs, file IDs, preview URLs or direct download URLs in this viewer.
+
 ### Standard PDF viewer
 
-Use `amd/src/pdfviewer.js` for one-page protected PDF rendering.
+Use `amd/src/pdfviewer.js` for one-page protected PDF rendering when a non-book fallback is required.
 
 ### Mobile PDF stabilizer
 
@@ -102,6 +117,7 @@ Presentation CSS is split by responsibility:
 
 ```text
 styles.css                         Base plugin styles loaded by Moodle.
+styles_bookviewer.css              Protected book viewer layout and fullscreen navigation.
 styles_pdf_overlay.css             PDF.js overlay and canvas behavior.
 styles_pdf_mobile.css              Mobile PDF-specific viewport rules.
 styles_visual_refinements.css      Product-level visual polish for Drive Resource.
@@ -111,12 +127,12 @@ Keep mobile fixes isolated from the generic styles whenever possible. This reduc
 
 ### Ebook viewer
 
-Use `amd/src/ebookviewer.js` for ebook rendering.
+Use `amd/src/ebookviewer.js` for optional legacy ebook rendering.
 
 Rules:
 
 - Load PDF.js locally.
-- Load PageFlip locally from `thirdpartylibs/pageflip`.
+- Load PageFlip locally from `thirdpartylibs/pageflip` when using PageFlip-specific behavior.
 - Keep fallback to `pdfviewer.js` if PageFlip is missing.
 - Do not use CDN.
 - Do not expose raw source URLs.
@@ -195,3 +211,4 @@ Before release:
 - PHP warnings clean.
 - JavaScript console clean.
 - mobile PDF viewer tested on iOS Safari, Android Chrome and Moodle app WebView.
+- desktop book viewer tested with portrait PDFs and landscape PDFs.

--- a/styles_bookviewer.css
+++ b/styles_bookviewer.css
@@ -1,0 +1,277 @@
+.mod-videoplayer-book {
+    --drive-book-bg: #f8fafc;
+    --drive-book-panel: #ffffff;
+    --drive-book-border: rgba(100, 116, 139, .22);
+    --drive-book-shadow: 0 22px 54px rgba(15, 23, 42, .16);
+    --drive-book-accent: var(--bs-primary, var(--primary, #06b6c9));
+}
+
+.mod-videoplayer-book-reader {
+    width: 100%;
+    max-width: 1180px;
+    margin: 0 auto;
+}
+
+.mod-videoplayer-book-stage {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: clamp(560px, 78vh, 900px);
+    padding: clamp(1rem, 2vw, 1.5rem);
+    overflow: hidden;
+    border: 1px solid var(--drive-book-border);
+    border-radius: 1.25rem;
+    background:
+        radial-gradient(circle at 15% 0%, rgba(6, 182, 201, .12), transparent 22rem),
+        radial-gradient(circle at 85% 0%, rgba(59, 130, 246, .10), transparent 24rem),
+        linear-gradient(135deg, #f8fafc, #e2e8f0);
+    box-shadow: var(--drive-book-shadow);
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+}
+
+.mod-videoplayer-book-pages {
+    position: relative;
+    z-index: 2;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(.6rem, 1.4vw, 1.25rem);
+    align-items: center;
+    justify-content: center;
+    width: min(100%, 1040px);
+    transition: transform .24s ease, opacity .2s ease;
+}
+
+.mod-videoplayer-book-pages.is-turning {
+    opacity: .72;
+    transform: scale(.985) rotateY(-2deg);
+}
+
+.mod-videoplayer-book-page {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    overflow: hidden;
+    border-radius: .75rem;
+    background: var(--drive-book-panel);
+    box-shadow:
+        0 18px 42px rgba(15, 23, 42, .18),
+        inset 10px 0 26px rgba(15, 23, 42, .045);
+}
+
+.mod-videoplayer-book-page.is-empty {
+    visibility: hidden;
+}
+
+.mod-videoplayer-book-page canvas {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-user-drag: none;
+}
+
+.mod-videoplayer-book-nav,
+.mod-videoplayer-book-fullscreen {
+    position: absolute;
+    z-index: 8;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, .94);
+    color: #0f172a;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, .18);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    cursor: pointer;
+}
+
+.mod-videoplayer-book-nav {
+    top: 50%;
+    width: 3.25rem;
+    height: 3.25rem;
+    font-size: 2.5rem;
+    line-height: 1;
+    transform: translateY(-50%);
+}
+
+.mod-videoplayer-book-nav:hover,
+.mod-videoplayer-book-nav:focus,
+.mod-videoplayer-book-fullscreen:hover,
+.mod-videoplayer-book-fullscreen:focus {
+    outline: 3px solid rgba(6, 182, 201, .22);
+    outline-offset: 2px;
+    background: #ffffff;
+}
+
+.mod-videoplayer-book-nav:disabled {
+    opacity: .35;
+    cursor: not-allowed;
+}
+
+.mod-videoplayer-book-nav-prev {
+    left: .9rem;
+}
+
+.mod-videoplayer-book-nav-next {
+    right: .9rem;
+}
+
+.mod-videoplayer-book-topbar {
+    position: absolute;
+    top: .85rem;
+    left: 50%;
+    z-index: 9;
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    transform: translateX(-50%);
+}
+
+.mod-videoplayer-book-status,
+.mod-videoplayer-book-fullscreen {
+    min-height: 2.5rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, .95);
+    box-shadow: 0 12px 26px rgba(15, 23, 42, .14);
+}
+
+.mod-videoplayer-book-status {
+    display: inline-flex;
+    align-items: center;
+    padding: .45rem .8rem;
+    font-weight: 800;
+    color: #0f172a;
+}
+
+.mod-videoplayer-book-fullscreen {
+    position: static;
+    width: 2.5rem;
+    height: 2.5rem;
+    color: #ffffff;
+    background: var(--drive-book-accent);
+}
+
+.mod-videoplayer-book-loading {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    display: flex;
+    gap: .8rem;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    color: #475569;
+    background: rgba(248, 250, 252, .96);
+}
+
+.mod-videoplayer-book-error {
+    margin-top: 1rem;
+}
+
+.mod-videoplayer-book-reader:fullscreen,
+.is-fallback-fullscreen.mod-videoplayer-book-reader {
+    width: 100vw !important;
+    height: 100vh !important;
+    max-width: none !important;
+    padding: 0 !important;
+    background: #0f172a;
+}
+
+.mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-stage,
+.is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-stage {
+    width: 100vw !important;
+    height: 100vh !important;
+    min-height: 100vh !important;
+    border: 0;
+    border-radius: 0;
+    background: #0f172a;
+}
+
+.mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-pages,
+.is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-pages {
+    width: min(100vw - 7rem, 1280px);
+}
+
+@media (max-width: 767.98px) {
+    .mod-videoplayer-book-reader {
+        max-width: none;
+        margin: 0;
+    }
+
+    .mod-videoplayer-book-stage {
+        min-height: auto;
+        padding: .6rem .4rem 4.25rem;
+        border-radius: 1rem;
+        background: #f8fafc;
+    }
+
+    .mod-videoplayer-book-pages {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0;
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .mod-videoplayer-book-page {
+        width: 100%;
+        max-width: 100%;
+        border-radius: .8rem;
+        box-shadow: 0 14px 34px rgba(15, 23, 42, .18);
+        transform-origin: center right;
+    }
+
+    .mod-videoplayer-book-page.is-mobile-turning {
+        animation: mod-videoplayer-mobile-flip .22s ease;
+    }
+
+    .mod-videoplayer-book-nav {
+        top: auto;
+        bottom: .7rem;
+        width: 3rem;
+        height: 3rem;
+        font-size: 2.15rem;
+        transform: none;
+    }
+
+    .mod-videoplayer-book-nav-prev {
+        left: .75rem;
+    }
+
+    .mod-videoplayer-book-nav-next {
+        right: .75rem;
+    }
+
+    .mod-videoplayer-book-topbar {
+        top: .7rem;
+    }
+
+    .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-stage,
+    .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-stage {
+        min-height: 100svh !important;
+        height: 100svh !important;
+        padding: calc(env(safe-area-inset-top, 0px) + .75rem) .45rem calc(env(safe-area-inset-bottom, 0px) + 4.5rem);
+    }
+
+    .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-pages,
+    .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-pages {
+        width: 100%;
+    }
+}
+
+@keyframes mod-videoplayer-mobile-flip {
+    from {
+        opacity: .55;
+        transform: translateX(1rem) rotateY(-8deg) scale(.985);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0) rotateY(0) scale(1);
+    }
+}

--- a/templates/book.mustache
+++ b/templates/book.mustache
@@ -1,0 +1,58 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    @template mod_videoplayer/book
+
+    Protected PDF book reader for Drive Resource.
+}}
+<div class="mod-videoplayer-container mod-videoplayer-book" data-resource-type="{{type}}" data-cmid="{{cmid}}">
+    <div class="mod-videoplayer-meta mb-2">
+        <span class="mod-videoplayer-meta-item">{{resourcetype}}</span>
+        <span class="mod-videoplayer-meta-item">{{#str}} protectedresource, mod_videoplayer {{/str}}</span>
+        {{#completionpercent}}
+            <span class="mod-videoplayer-meta-item" data-region="book-progress">{{completionpercent}}%</span>
+        {{/completionpercent}}
+    </div>
+
+    <div class="mod-videoplayer-book-reader"
+         data-pdf-url="{{pdfurl}}"
+         data-title="{{title}}"
+         data-cmid="{{cmid}}"
+         data-initial-page="{{initialpage}}"
+         data-disable-context-menu="{{#disablecontextmenu}}1{{/disablecontextmenu}}{{^disablecontextmenu}}0{{/disablecontextmenu}}"
+         data-watermark="{{#enablewatermark}}{{watermark}}{{/enablewatermark}}"
+         oncontextmenu="return false;">
+
+        <div class="mod-videoplayer-book-stage" data-region="book-stage" aria-label="{{title}}">
+            <div class="mod-videoplayer-book-loading" data-region="book-loading">
+                <span class="mod-videoplayer-pdfjs-spinner" aria-hidden="true"></span>
+                <span>{{#str}} loadingpdf, mod_videoplayer {{/str}}</span>
+            </div>
+
+            <button type="button" class="mod-videoplayer-book-nav mod-videoplayer-book-nav-prev" data-action="previous-page" title="{{#str}} previouspage, mod_videoplayer {{/str}}" aria-label="{{#str}} previouspage, mod_videoplayer {{/str}}">
+                <span aria-hidden="true">‹</span>
+            </button>
+
+            <div class="mod-videoplayer-book-pages" data-region="book-pages"></div>
+
+            <button type="button" class="mod-videoplayer-book-nav mod-videoplayer-book-nav-next" data-action="next-page" title="{{#str}} nextpage, mod_videoplayer {{/str}}" aria-label="{{#str}} nextpage, mod_videoplayer {{/str}}">
+                <span aria-hidden="true">›</span>
+            </button>
+
+            <div class="mod-videoplayer-book-topbar">
+                <span class="mod-videoplayer-book-status" aria-live="polite">
+                    <span data-region="current-page">1</span> / <span data-region="total-pages">-</span>
+                </span>
+                <button type="button" class="mod-videoplayer-book-fullscreen" data-action="fullscreen" title="{{#str}} fullscreen, mod_videoplayer {{/str}}" aria-label="{{#str}} fullscreen, mod_videoplayer {{/str}}">
+                    <span aria-hidden="true">⛶</span>
+                </button>
+            </div>
+
+            {{#enablewatermark}}
+                <div class="mod-videoplayer-watermark" aria-hidden="true">{{watermark}}</div>
+            {{/enablewatermark}}
+        </div>
+
+        <div class="mod-videoplayer-book-error alert alert-danger" data-region="book-error" hidden>{{#str}} pdfjsrequired, mod_videoplayer {{/str}}</div>
+    </div>
+</div>

--- a/view.php
+++ b/view.php
@@ -88,7 +88,7 @@ if (!isguestuser()) {
 $initialprogress = $progressrecord ? (float) $progressrecord->progress : 0;
 $completed = $progressrecord ? (bool) $progressrecord->completed : false;
 $requiredseconds = max(60, ((int) ($videoplayer->completionpercentage ?? 80)) * 6);
-$displaymode = 'standard';
+$displaymode = 'book';
 
 if (!isguestuser()) {
     $PAGE->requires->js_call_amd('mod_videoplayer/progress', 'init', [[
@@ -101,10 +101,8 @@ if (!isguestuser()) {
 }
 
 if ($type === 'pdf') {
-    $PAGE->requires->css('/mod/videoplayer/styles_pdf_overlay.css');
-    $PAGE->requires->css('/mod/videoplayer/styles_pdf_mobile.css');
-    $PAGE->requires->js_call_amd('mod_videoplayer/pdfviewer', 'init');
-    $PAGE->requires->js_call_amd('mod_videoplayer/pdfmobile', 'init');
+    $PAGE->requires->css('/mod/videoplayer/styles_bookviewer.css');
+    $PAGE->requires->js_call_amd('mod_videoplayer/bookviewer', 'init');
 } else if ($type === 'video') {
     $PAGE->requires->css('/mod/videoplayer/thirdpartylibs/plyr/plyr.css');
     $PAGE->requires->js_call_amd('mod_videoplayer/plyr', 'init');
@@ -135,7 +133,7 @@ $templatecontext = [
     'title' => format_string($videoplayer->name),
     'playerstyle' => $playerstyle,
     'displaymode' => $displaymode,
-    'ebookmode' => false,
+    'ebookmode' => true,
     'disabledownload' => !empty($videoplayer->disabledownload),
     'disablecontextmenu' => !empty($videoplayer->disablecontextmenu),
     'enablewatermark' => !empty($videoplayer->enablewatermark),
@@ -159,7 +157,7 @@ if (!empty($videoplayer->intro)) {
 }
 
 if ($type === 'pdf') {
-    echo $OUTPUT->render_from_template('mod_videoplayer/pdfjs', $templatecontext);
+    echo $OUTPUT->render_from_template('mod_videoplayer/book', $templatecontext);
 } else if ($type === 'video') {
     echo $OUTPUT->render_from_template('mod_videoplayer/video', $templatecontext);
 } else {


### PR DESCRIPTION
## Summary

Adds a protected responsive book viewer for Drive Resource PDF content.

## User-facing behavior

- Desktop renders PDFs as a two-page book spread.
- Mobile renders one page at a time, similar to FlipHTML5-style reading.
- Fullscreen keeps previous and next navigation buttons inside the PDF/book stage.
- Mobile supports swipe navigation.
- PDF content remains delivered through `protected.php`.

## Changes

- Adds `templates/book.mustache`.
- Adds `amd/src/bookviewer.js`.
- Adds `styles_bookviewer.css`.
- Updates `view.php` to use the protected book viewer for PDF resources.
- Updates `CHANGELOG.md`.
- Updates `docs/developer-guide.md`.

## Validation required

- Purge Moodle caches after deployment.
- Run `grunt amd` if AMD build artifacts are used.
- Test desktop two-page spread in Chrome and Firefox.
- Test mobile one-page mode in iPhone Safari and Android Chrome.
- Test fullscreen navigation buttons remain inside the viewer.

## Security notes

`protected.php` and the proxy/security flow are intentionally untouched. The book viewer still receives only the protected Moodle URL.