### PR TITLE
Fix book controls and start page behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Protected responsive book viewer with desktop two-page spread and mobile one-page reading mode.
 - In-memory rendered page cache and neighbor-page prefetch for the protected book viewer.
 - Desktop book spine, center fold shadows and directional ebook-style page turn effects.
+- Dedicated book control placement stylesheet for coherent navigation and fullscreen UI.
 
 ### Changed
 
@@ -45,6 +46,8 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Protected range responses now use short private browser caching with `no-transform` instead of global `no-store`.
 - Protected streaming chunk size increased to reduce PHP flush overhead.
 - Book viewer pages now receive left/right page classes and turn-direction classes for realistic desktop transitions.
+- Book viewer controls now place page status at the top center, fullscreen at the top right and previous/next controls at the viewer sides.
+- Protected book PDFs now start from page 1 on every page load instead of resuming the last viewed page.
 
 ### Security
 

--- a/styles_book_controls.css
+++ b/styles_book_controls.css
@@ -1,0 +1,118 @@
+/*
+ * Drive Resource book viewer control placement.
+ *
+ * Keeps navigation and fullscreen controls predictable in desktop, fullscreen
+ * and mobile layouts without changing the protected streaming flow.
+ */
+
+.mod-videoplayer-book-stage {
+    --drive-book-control-offset: clamp(.85rem, 1.8vw, 1.45rem);
+}
+
+.mod-videoplayer-book-nav {
+    z-index: 14;
+    opacity: .96;
+}
+
+.mod-videoplayer-book-nav-prev {
+    left: var(--drive-book-control-offset);
+}
+
+.mod-videoplayer-book-nav-next {
+    right: var(--drive-book-control-offset);
+}
+
+.mod-videoplayer-book-topbar {
+    top: .85rem;
+    right: .95rem;
+    left: .95rem;
+    z-index: 15;
+    display: block;
+    height: 2.8rem;
+    pointer-events: none;
+    transform: none;
+}
+
+.mod-videoplayer-book-status {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    min-width: 4.25rem;
+    justify-content: center;
+    transform: translateX(-50%);
+}
+
+.mod-videoplayer-book-fullscreen {
+    position: absolute;
+    top: 0;
+    right: 0;
+    pointer-events: auto;
+}
+
+.mod-videoplayer-book-status {
+    pointer-events: none;
+}
+
+.mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-nav-prev,
+.is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-nav-prev {
+    left: max(1.25rem, env(safe-area-inset-left, 0px));
+}
+
+.mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-nav-next,
+.is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-nav-next {
+    right: max(1.25rem, env(safe-area-inset-right, 0px));
+}
+
+.mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-topbar,
+.is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-topbar {
+    top: max(1rem, env(safe-area-inset-top, 0px));
+    right: max(1.25rem, env(safe-area-inset-right, 0px));
+    left: max(1.25rem, env(safe-area-inset-left, 0px));
+}
+
+@media (max-width: 767.98px) {
+    .mod-videoplayer-book-topbar {
+        top: .65rem;
+        right: .65rem;
+        left: .65rem;
+        height: 2.75rem;
+    }
+
+    .mod-videoplayer-book-status {
+        min-width: 3.9rem;
+        min-height: 2.35rem;
+        padding: .38rem .7rem;
+        font-size: .88rem;
+    }
+
+    .mod-videoplayer-book-fullscreen {
+        width: 2.5rem;
+        height: 2.5rem;
+    }
+
+    .mod-videoplayer-book-nav {
+        bottom: .85rem;
+        width: 3.15rem;
+        height: 3.15rem;
+    }
+
+    .mod-videoplayer-book-nav-prev {
+        left: .85rem;
+    }
+
+    .mod-videoplayer-book-nav-next {
+        right: .85rem;
+    }
+
+    .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-topbar,
+    .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-topbar {
+        top: calc(env(safe-area-inset-top, 0px) + .75rem);
+        right: calc(env(safe-area-inset-right, 0px) + .75rem);
+        left: calc(env(safe-area-inset-left, 0px) + .75rem);
+    }
+
+    .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-nav,
+    .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-nav {
+        bottom: calc(env(safe-area-inset-bottom, 0px) + .85rem);
+    }
+}

--- a/view.php
+++ b/view.php
@@ -102,6 +102,7 @@ if (!isguestuser()) {
 
 if ($type === 'pdf') {
     $PAGE->requires->css('/mod/videoplayer/styles_bookviewer.css');
+    $PAGE->requires->css('/mod/videoplayer/styles_book_controls.css');
     $PAGE->requires->js_call_amd('mod_videoplayer/bookviewer', 'init');
 } else if ($type === 'video') {
     $PAGE->requires->css('/mod/videoplayer/thirdpartylibs/plyr/plyr.css');
@@ -116,7 +117,7 @@ if (get_config('mod_videoplayer', 'playercolormode') === 'custom') {
     }
 }
 
-$initialpage = ($source === 'localpdf') ? 1 : ($progressrecord && !empty($progressrecord->lastpage) ? (int)$progressrecord->lastpage : 1);
+$initialpage = 1;
 $totalpages = ($source === 'localpdf') ? 0 : ($progressrecord && !empty($progressrecord->totalpages) ? (int)$progressrecord->totalpages : 0);
 $points = $progressrecord && !empty($progressrecord->points) ? (int)$progressrecord->points : 0;
 $completionpercent = $progressrecord ? (float)$progressrecord->completionpercentage : 0;
@@ -139,7 +140,7 @@ $templatecontext = [
     'enablewatermark' => !empty($videoplayer->enablewatermark),
     'enablegamification' => !empty($videoplayer->enablegamification),
     'pointsperpage' => (int)($videoplayer->pointsperpage ?? 1),
-    'initialpage' => max(1, $initialpage),
+    'initialpage' => 1,
     'totalpages' => $totalpages,
     'points' => $points,
     'completionpercent' => round($completionpercent, 2),


### PR DESCRIPTION
## Summary

Improves Drive Resource protected book viewer controls and resets PDF book loading to page 1 on every page load.

## Changes

- Adds `styles_book_controls.css` for coherent control placement.
- Places previous navigation on the left side of the viewer.
- Places next navigation on the right side of the viewer.
- Places page status at the top center.
- Places fullscreen at the top right.
- Applies safe-area aware placement for fullscreen/mobile modes.
- Loads the new control stylesheet from `view.php` after the main book viewer stylesheet.
- Forces protected book PDFs to start from page 1 on each reload.
- Updates changelog documentation.

## Validation

- Purge Moodle caches after deployment.
- Test desktop normal mode and fullscreen mode.
- Test mobile mode and mobile fullscreen.
- Reload the activity after visiting later pages and confirm it starts at page 1.