### PR TITLE
Improve PDF first render and cache diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - In-memory rendered page cache and neighbor-page prefetch for the protected book viewer.
 - Desktop book spine, center fold shadows and directional ebook-style page turn effects.
 - Dedicated book control placement stylesheet for coherent navigation and fullscreen UI.
+- Protected stream cache diagnostic header `X-Drive-Resource-Cache`.
 
 ### Changed
 
@@ -48,6 +49,8 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Book viewer pages now receive left/right page classes and turn-direction classes for realistic desktop transitions.
 - Book viewer controls now place page status at the top center, fullscreen at the top right and previous/next controls at the viewer sides.
 - Protected book PDFs now start from page 1 on every page load instead of resuming the last viewed page.
+- Book viewer now hides the loading overlay as soon as the first visible page is rendered instead of waiting for the full desktop spread.
+- Local Moodle PDFs are streamed directly from Moodle File API storage when possible, avoiding a full temporary copy before delivery.
 
 ### Security
 

--- a/amd/build/bookviewer.min.js
+++ b/amd/build/bookviewer.min.js
@@ -1,1 +1,538 @@
-define(['core/ajax','core/notification'],function(Ajax,Notification){const PDFJS_URL=M.cfg.wwwroot+'/mod/videoplayer/thirdpartylibs/pdfjs/pdf.min.mjs';const PDFJS_WORKER_URL=M.cfg.wwwroot+'/mod/videoplayer/thirdpartylibs/pdfjs/pdf.worker.min.mjs';const SAVE_INTERVAL=10000;const MOBILE_QUERY='(max-width: 767.98px)';const MOBILE_CACHE_LIMIT=5;const DESKTOP_CACHE_LIMIT=8;const PREFETCH_DELAY=80;let pdfjsPromise=null;const loadPdfJs=function(){if(!pdfjsPromise){pdfjsPromise=import(PDFJS_URL).then(function(pdfjsLib){pdfjsLib.GlobalWorkerOptions.workerSrc=PDFJS_WORKER_URL;return pdfjsLib;});}return pdfjsPromise;};const isMobile=function(){return window.matchMedia(MOBILE_QUERY).matches;};const hide=function(node,value){if(node){node.hidden=value;}};const block=function(event){event.preventDefault();event.stopPropagation();return false;};const hardenViewer=function(root){if(root.getAttribute('data-disable-context-menu')!=='1'){return;}['contextmenu','dragstart','copy','cut','paste','selectstart'].forEach(function(name){root.addEventListener(name,block,true);});root.addEventListener('keydown',function(event){const key=(event.key||'').toLowerCase();if((event.ctrlKey||event.metaKey)&&['s','p','c','a'].indexOf(key)!==-1){block(event);}},true);};const initViewer=function(root,pdfjsLib){const pdfUrl=root.getAttribute('data-pdf-url');const cmid=parseInt(root.getAttribute('data-cmid'),10)||0;const initialPage=Math.max(1,parseInt(root.getAttribute('data-initial-page'),10)||1);const reader=root.closest('.mod-videoplayer-book-reader')||root;const stage=root.querySelector('[data-region="book-stage"]');const pagesRegion=root.querySelector('[data-region="book-pages"]');const previous=root.querySelector('[data-action="previous-page"]');const next=root.querySelector('[data-action="next-page"]');const fullscreen=root.querySelector('[data-action="fullscreen"]');const currentPageNode=root.querySelector('[data-region="current-page"]');const totalPagesNode=root.querySelector('[data-region="total-pages"]');const loading=root.querySelector('[data-region="book-loading"]');const error=root.querySelector('[data-region="book-error"]');const progressNode=(root.closest('.mod-videoplayer-container')||document).querySelector('[data-region="book-progress"]');if(!pdfUrl||!stage||!pagesRegion){hide(loading,true);hide(error,false);return;}hardenViewer(root);let pdfDocument=null;let pageNumber=initialPage;let rendering=false;let pendingPage=null;let lastSave=0;let activeSeconds=0;let lastTick=Date.now();let completed=false;let touchStartX=0;let touchStartY=0;let touchMoved=false;let renderVersion=0;let turnDirection='forward';const pageCache=new Map();const renderPromises=new Map();const getSpreadStart=function(num){if(isMobile()){return num;}return num<=1?1:(num%2===0?num:num-1);};const getVisiblePages=function(){if(!pdfDocument){return [];}if(isMobile()){return[pageNumber];}const start=getSpreadStart(pageNumber);const pages=[start];if(start+1<=pdfDocument.numPages){pages.push(start+1);}return pages;};const getCacheKey=function(pageIndex){return[isMobile()?'m':'d',Math.round(getPageWidth()),pageIndex].join(':');};const pruneCache=function(){const limit=isMobile()?MOBILE_CACHE_LIMIT:DESKTOP_CACHE_LIMIT;while(pageCache.size>limit){const firstKey=pageCache.keys().next().value;pageCache.delete(firstKey);}};const clearPageCache=function(){pageCache.clear();renderPromises.clear();};const updateStatus=function(){if(!pdfDocument){return;}if(currentPageNode){const pages=getVisiblePages();currentPageNode.textContent=pages.length>1?pages[0]+'-'+pages[1]:String(pageNumber);}if(totalPagesNode){totalPagesNode.textContent=String(pdfDocument.numPages);}if(previous){previous.disabled=pageNumber<=1;}if(next){next.disabled=pageNumber>=pdfDocument.numPages;}};const completionPercent=function(){if(!pdfDocument||!pdfDocument.numPages){return 0;}return Math.min(100,Math.round((pageNumber/pdfDocument.numPages)*10000)/100);};const saveProgress=function(force){if(!cmid||!pdfDocument){return Promise.resolve();}const now=Date.now();if(!force&&now-lastSave<SAVE_INTERVAL){return Promise.resolve();}activeSeconds+=Math.max(0,Math.round((now-lastTick)/1000));lastTick=now;lastSave=now;const percent=completionPercent();completed=completed||percent>=100;return Ajax.call([{methodname:'mod_videoplayer_save_progress',args:{cmid:cmid,progress:activeSeconds,completed:completed,completionpercentage:percent,lastpage:pageNumber,totalpages:pdfDocument.numPages,timespent:activeSeconds}}])[0].then(function(response){if(response){completed=Boolean(response.completed);if(progressNode){progressNode.textContent=response.completionpercentage+'%';}}return response;}).catch(Notification.exception);};const getPageWidth=function(){const stageWidth=Math.max(stage.clientWidth-(isMobile()?24:128),280);return isMobile()?Math.min(stageWidth,720):Math.min(stageWidth/2,560);};const renderPageCanvas=function(pageIndex){const cacheKey=getCacheKey(pageIndex);if(pageCache.has(cacheKey)){const cached=pageCache.get(cacheKey);pageCache.delete(cacheKey);pageCache.set(cacheKey,cached);return Promise.resolve(cached);}if(renderPromises.has(cacheKey)){return renderPromises.get(cacheKey);}const promise=pdfDocument.getPage(pageIndex).then(function(page){const base=page.getViewport({scale:1});const targetWidth=getPageWidth();const scale=Math.min(Math.max(targetWidth/base.width,0.5),2.2);const viewport=page.getViewport({scale:scale});const outputScale=Math.min(window.devicePixelRatio||1,2);const canvas=document.createElement('canvas');const context=canvas.getContext('2d');canvas.width=Math.floor(viewport.width*outputScale);canvas.height=Math.floor(viewport.height*outputScale);canvas.style.width=Math.floor(viewport.width)+'px';canvas.style.height=Math.floor(viewport.height)+'px';canvas.setAttribute('draggable','false');return page.render({canvasContext:context,viewport:viewport,transform:outputScale!==1?[outputScale,0,0,outputScale,0,0]:null}).promise.then(function(){pageCache.set(cacheKey,canvas);pruneCache();return canvas;});}).finally(function(){renderPromises.delete(cacheKey);});renderPromises.set(cacheKey,promise);return promise;};const getPrefetchPages=function(){if(!pdfDocument){return [];}if(isMobile()){return[pageNumber+1,pageNumber-1].filter(function(num){return num>=1&&num<=pdfDocument.numPages;});}const start=getSpreadStart(pageNumber);return[start+2,start+3,start-1,start-2].filter(function(num){return num>=1&&num<=pdfDocument.numPages;});};const prefetchPages=function(){window.setTimeout(function(){getPrefetchPages().forEach(function(num){renderPageCanvas(num).catch(function(){});});},PREFETCH_DELAY);};const createPageNode=function(canvas,pageIndex,position){const pageNode=document.createElement('div');pageNode.className='mod-videoplayer-book-page';pageNode.setAttribute('data-page-number',String(pageIndex));if(isMobile()){pageNode.classList.add('mod-videoplayer-book-page-single','is-mobile-turning');pageNode.classList.add(turnDirection==='backward'?'is-mobile-turning-backward':'is-mobile-turning-forward');}else{const side=position===0?'left':'right';pageNode.classList.add('mod-videoplayer-book-page-'+side);if(turnDirection==='forward'&&side==='right'){pageNode.classList.add('is-turning-forward');}else if(turnDirection==='backward'&&side==='left'){pageNode.classList.add('is-turning-backward');}}pageNode.appendChild(canvas);return pageNode;};const renderSpread=function(){if(!pdfDocument||rendering){return;}const currentRenderVersion=++renderVersion;rendering=true;pagesRegion.classList.remove('is-turning-forward','is-turning-backward');pagesRegion.classList.add('is-turning',turnDirection==='backward'?'is-turning-backward':'is-turning-forward');hide(loading,false);pagesRegion.innerHTML='';const visiblePages=getVisiblePages();const renderers=visiblePages.map(function(num,position){return renderPageCanvas(num).then(function(canvas){if(currentRenderVersion!==renderVersion){return;}pagesRegion.appendChild(createPageNode(canvas,num,position));});});Promise.all(renderers).then(function(){if(currentRenderVersion!==renderVersion){return;}if(!isMobile()&&visiblePages.length===1){const empty=document.createElement('div');empty.className='mod-videoplayer-book-page mod-videoplayer-book-page-right is-empty';pagesRegion.appendChild(empty);}rendering=false;hide(loading,true);pagesRegion.classList.remove('is-turning','is-turning-forward','is-turning-backward');updateStatus();saveProgress(false);prefetchPages();if(pendingPage!==null){const queued=pendingPage;pendingPage=null;goToPage(queued);}}).catch(function(err){rendering=false;hide(loading,true);pagesRegion.classList.remove('is-turning','is-turning-forward','is-turning-backward');hide(error,false);Notification.exception(err);});};const goToPage=function(num){if(!pdfDocument){return;}const previousPage=pageNumber;const safe=Math.max(1,Math.min(pdfDocument.numPages,num));const targetPage=isMobile()?safe:getSpreadStart(safe);turnDirection=targetPage<previousPage?'backward':'forward';pageNumber=targetPage;if(rendering){pendingPage=pageNumber;return;}renderSpread();};if(previous){previous.addEventListener('click',function(){goToPage(pageNumber-(isMobile()?1:2));});}if(next){next.addEventListener('click',function(){goToPage(pageNumber+(isMobile()?1:2));});}if(fullscreen){fullscreen.addEventListener('click',function(){if(document.fullscreenElement){document.exitFullscreen();return;}if(reader.requestFullscreen){reader.requestFullscreen().catch(function(){reader.classList.add('is-fallback-fullscreen');});}else{reader.classList.add('is-fallback-fullscreen');}});document.addEventListener('fullscreenchange',function(){if(!document.fullscreenElement){reader.classList.remove('is-fallback-fullscreen');}clearPageCache();window.setTimeout(renderSpread,160);});}stage.addEventListener('touchstart',function(event){if(!event.touches||event.touches.length!==1){return;}touchMoved=false;touchStartX=event.touches[0].clientX;touchStartY=event.touches[0].clientY;},{passive:true});stage.addEventListener('touchmove',function(event){if(!event.touches||event.touches.length!==1){return;}const dx=event.touches[0].clientX-touchStartX;const dy=event.touches[0].clientY-touchStartY;touchMoved=Math.abs(dx)>20||Math.abs(dy)>20;},{passive:true});stage.addEventListener('touchend',function(event){if(!touchMoved||!pdfDocument){return;}const changed=event.changedTouches&&event.changedTouches[0];if(!changed){return;}const dx=changed.clientX-touchStartX;const dy=changed.clientY-touchStartY;if(Math.abs(dx)<60||Math.abs(dx)<Math.abs(dy)*1.35){return;}goToPage(pageNumber+(dx<0?1:-1));},{passive:true});window.addEventListener('resize',function(){clearPageCache();window.setTimeout(renderSpread,120);});window.addEventListener('orientationchange',function(){clearPageCache();window.setTimeout(renderSpread,280);});window.addEventListener('beforeunload',function(){saveProgress(true);});document.addEventListener('visibilitychange',function(){if(document.hidden){saveProgress(true);}else{lastTick=Date.now();}});hide(loading,false);pdfjsLib.getDocument({url:pdfUrl,withCredentials:true,rangeChunkSize:262144}).promise.then(function(pdf){pdfDocument=pdf;pageNumber=Math.min(initialPage,pdfDocument.numPages);if(!isMobile()){pageNumber=getSpreadStart(pageNumber);}updateStatus();renderSpread();}).catch(function(err){hide(loading,true);hide(error,false);Notification.exception(err);});};const init=function(){const roots=Array.prototype.slice.call(document.querySelectorAll('.mod-videoplayer-book-reader'));if(!roots.length){return;}loadPdfJs().then(function(pdfjsLib){roots.forEach(function(root){initViewer(root,pdfjsLib);});}).catch(function(err){Notification.exception(err);roots.forEach(function(root){hide(root.querySelector('[data-region="book-loading"]'),true);hide(root.querySelector('[data-region="book-error"]'),false);});});};return{init:init};});
+// This file is part of Moodle - http://moodle.org/
+
+/**
+ * Protected responsive book viewer for Drive Resource.
+ *
+ * Desktop renders a two-page spread. Mobile renders one page with a light
+ * flip-style transition. The PDF source remains protected through Moodle.
+ *
+ * @module     mod_videoplayer/bookviewer
+ * @copyright  2026 Jose Erasmo Moreno Salgado - Elearning Cloud
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
+    const PDFJS_URL = M.cfg.wwwroot + '/mod/videoplayer/thirdpartylibs/pdfjs/pdf.min.mjs';
+    const PDFJS_WORKER_URL = M.cfg.wwwroot + '/mod/videoplayer/thirdpartylibs/pdfjs/pdf.worker.min.mjs';
+    const SAVE_INTERVAL = 10000;
+    const MOBILE_QUERY = '(max-width: 767.98px)';
+    const MOBILE_CACHE_LIMIT = 5;
+    const DESKTOP_CACHE_LIMIT = 8;
+    const PREFETCH_DELAY = 80;
+    let pdfjsPromise = null;
+
+    const loadPdfJs = function() {
+        if (!pdfjsPromise) {
+            pdfjsPromise = import(PDFJS_URL).then(function(pdfjsLib) {
+                pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_URL;
+                return pdfjsLib;
+            });
+        }
+        return pdfjsPromise;
+    };
+
+    const isMobile = function() {
+        return window.matchMedia(MOBILE_QUERY).matches;
+    };
+
+    const hide = function(node, value) {
+        if (node) {
+            node.hidden = value;
+        }
+    };
+
+    const block = function(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        return false;
+    };
+
+    const hardenViewer = function(root) {
+        if (root.getAttribute('data-disable-context-menu') !== '1') {
+            return;
+        }
+        ['contextmenu', 'dragstart', 'copy', 'cut', 'paste', 'selectstart'].forEach(function(name) {
+            root.addEventListener(name, block, true);
+        });
+        root.addEventListener('keydown', function(event) {
+            const key = (event.key || '').toLowerCase();
+            if ((event.ctrlKey || event.metaKey) && ['s', 'p', 'c', 'a'].indexOf(key) !== -1) {
+                block(event);
+            }
+        }, true);
+    };
+
+    const initViewer = function(root, pdfjsLib) {
+        const pdfUrl = root.getAttribute('data-pdf-url');
+        const cmid = parseInt(root.getAttribute('data-cmid'), 10) || 0;
+        const initialPage = Math.max(1, parseInt(root.getAttribute('data-initial-page'), 10) || 1);
+        const reader = root.closest('.mod-videoplayer-book-reader') || root;
+        const stage = root.querySelector('[data-region="book-stage"]');
+        const pagesRegion = root.querySelector('[data-region="book-pages"]');
+        const previous = root.querySelector('[data-action="previous-page"]');
+        const next = root.querySelector('[data-action="next-page"]');
+        const fullscreen = root.querySelector('[data-action="fullscreen"]');
+        const currentPageNode = root.querySelector('[data-region="current-page"]');
+        const totalPagesNode = root.querySelector('[data-region="total-pages"]');
+        const loading = root.querySelector('[data-region="book-loading"]');
+        const error = root.querySelector('[data-region="book-error"]');
+        const progressNode = (root.closest('.mod-videoplayer-container') || document).querySelector('[data-region="book-progress"]');
+
+        if (!pdfUrl || !stage || !pagesRegion) {
+            hide(loading, true);
+            hide(error, false);
+            return;
+        }
+
+        hardenViewer(root);
+
+        let pdfDocument = null;
+        let pageNumber = initialPage;
+        let rendering = false;
+        let pendingPage = null;
+        let lastSave = 0;
+        let activeSeconds = 0;
+        let lastTick = Date.now();
+        let completed = false;
+        let touchStartX = 0;
+        let touchStartY = 0;
+        let touchMoved = false;
+        let renderVersion = 0;
+        let turnDirection = 'forward';
+
+        const pageCache = new Map();
+        const renderPromises = new Map();
+
+        const getSpreadStart = function(num) {
+            if (isMobile()) {
+                return num;
+            }
+            return num <= 1 ? 1 : (num % 2 === 0 ? num : num - 1);
+        };
+
+        const getVisiblePages = function() {
+            if (!pdfDocument) {
+                return [];
+            }
+            if (isMobile()) {
+                return [pageNumber];
+            }
+            const start = getSpreadStart(pageNumber);
+            const pages = [start];
+            if (start + 1 <= pdfDocument.numPages) {
+                pages.push(start + 1);
+            }
+            return pages;
+        };
+
+        const getPageWidth = function() {
+            const stageWidth = Math.max(stage.clientWidth - (isMobile() ? 24 : 128), 280);
+            return isMobile() ? Math.min(stageWidth, 720) : Math.min(stageWidth / 2, 560);
+        };
+
+        const getCacheKey = function(pageIndex) {
+            return [isMobile() ? 'm' : 'd', Math.round(getPageWidth()), pageIndex].join(':');
+        };
+
+        const pruneCache = function() {
+            const limit = isMobile() ? MOBILE_CACHE_LIMIT : DESKTOP_CACHE_LIMIT;
+            while (pageCache.size > limit) {
+                const firstKey = pageCache.keys().next().value;
+                pageCache.delete(firstKey);
+            }
+        };
+
+        const clearPageCache = function() {
+            pageCache.clear();
+            renderPromises.clear();
+        };
+
+        const updateStatus = function() {
+            if (!pdfDocument) {
+                return;
+            }
+            if (currentPageNode) {
+                const pages = getVisiblePages();
+                currentPageNode.textContent = pages.length > 1 ? pages[0] + '-' + pages[1] : String(pageNumber);
+            }
+            if (totalPagesNode) {
+                totalPagesNode.textContent = String(pdfDocument.numPages);
+            }
+            if (previous) {
+                previous.disabled = pageNumber <= 1;
+            }
+            if (next) {
+                next.disabled = pageNumber >= pdfDocument.numPages;
+            }
+        };
+
+        const completionPercent = function() {
+            if (!pdfDocument || !pdfDocument.numPages) {
+                return 0;
+            }
+            return Math.min(100, Math.round((pageNumber / pdfDocument.numPages) * 10000) / 100);
+        };
+
+        const saveProgress = function(force) {
+            if (!cmid || !pdfDocument) {
+                return Promise.resolve();
+            }
+            const now = Date.now();
+            if (!force && now - lastSave < SAVE_INTERVAL) {
+                return Promise.resolve();
+            }
+            activeSeconds += Math.max(0, Math.round((now - lastTick) / 1000));
+            lastTick = now;
+            lastSave = now;
+            const percent = completionPercent();
+            completed = completed || percent >= 100;
+
+            return Ajax.call([{
+                methodname: 'mod_videoplayer_save_progress',
+                args: {
+                    cmid: cmid,
+                    progress: activeSeconds,
+                    completed: completed,
+                    completionpercentage: percent,
+                    lastpage: pageNumber,
+                    totalpages: pdfDocument.numPages,
+                    timespent: activeSeconds
+                }
+            }])[0].then(function(response) {
+                if (response) {
+                    completed = Boolean(response.completed);
+                    if (progressNode) {
+                        progressNode.textContent = response.completionpercentage + '%';
+                    }
+                }
+                return response;
+            }).catch(Notification.exception);
+        };
+
+        const renderPageCanvas = function(pageIndex) {
+            const cacheKey = getCacheKey(pageIndex);
+
+            if (pageCache.has(cacheKey)) {
+                const cached = pageCache.get(cacheKey);
+                pageCache.delete(cacheKey);
+                pageCache.set(cacheKey, cached);
+                return Promise.resolve(cached);
+            }
+
+            if (renderPromises.has(cacheKey)) {
+                return renderPromises.get(cacheKey);
+            }
+
+            const promise = pdfDocument.getPage(pageIndex).then(function(page) {
+                const base = page.getViewport({scale: 1});
+                const targetWidth = getPageWidth();
+                const scale = Math.min(Math.max(targetWidth / base.width, 0.5), 2.2);
+                const viewport = page.getViewport({scale: scale});
+                const outputScale = Math.min(window.devicePixelRatio || 1, 2);
+                const canvas = document.createElement('canvas');
+                const context = canvas.getContext('2d');
+
+                canvas.width = Math.floor(viewport.width * outputScale);
+                canvas.height = Math.floor(viewport.height * outputScale);
+                canvas.style.width = Math.floor(viewport.width) + 'px';
+                canvas.style.height = Math.floor(viewport.height) + 'px';
+                canvas.setAttribute('draggable', 'false');
+
+                return page.render({
+                    canvasContext: context,
+                    viewport: viewport,
+                    transform: outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null
+                }).promise.then(function() {
+                    pageCache.set(cacheKey, canvas);
+                    pruneCache();
+                    return canvas;
+                });
+            }).finally(function() {
+                renderPromises.delete(cacheKey);
+            });
+
+            renderPromises.set(cacheKey, promise);
+            return promise;
+        };
+
+        const getPrefetchPages = function() {
+            if (!pdfDocument) {
+                return [];
+            }
+
+            if (isMobile()) {
+                return [pageNumber + 1, pageNumber - 1].filter(function(num) {
+                    return num >= 1 && num <= pdfDocument.numPages;
+                });
+            }
+
+            const start = getSpreadStart(pageNumber);
+            return [start + 2, start + 3, start - 1, start - 2].filter(function(num) {
+                return num >= 1 && num <= pdfDocument.numPages;
+            });
+        };
+
+        const prefetchPages = function() {
+            window.setTimeout(function() {
+                getPrefetchPages().forEach(function(num) {
+                    renderPageCanvas(num).catch(function() {
+                        // Prefetch is best-effort and should never block reading.
+                    });
+                });
+            }, PREFETCH_DELAY);
+        };
+
+        const createPageNode = function(canvas, pageIndex, position) {
+            const pageNode = document.createElement('div');
+            pageNode.className = 'mod-videoplayer-book-page';
+            pageNode.setAttribute('data-page-number', String(pageIndex));
+
+            if (isMobile()) {
+                pageNode.classList.add('mod-videoplayer-book-page-single', 'is-mobile-turning');
+                pageNode.classList.add(turnDirection === 'backward' ? 'is-mobile-turning-backward' : 'is-mobile-turning-forward');
+            } else {
+                const side = position === 0 ? 'left' : 'right';
+                pageNode.classList.add('mod-videoplayer-book-page-' + side);
+                if (turnDirection === 'forward' && side === 'right') {
+                    pageNode.classList.add('is-turning-forward');
+                } else if (turnDirection === 'backward' && side === 'left') {
+                    pageNode.classList.add('is-turning-backward');
+                }
+            }
+
+            pageNode.appendChild(canvas);
+            return pageNode;
+        };
+
+        const createPlaceholderNode = function(referenceCanvas, position) {
+            const pageNode = document.createElement('div');
+            const side = position === 0 ? 'left' : 'right';
+            pageNode.className = 'mod-videoplayer-book-page mod-videoplayer-book-page-' + side + ' is-page-loading';
+            if (referenceCanvas) {
+                pageNode.style.width = referenceCanvas.style.width;
+                pageNode.style.height = referenceCanvas.style.height;
+            }
+            return pageNode;
+        };
+
+        const finishRender = function(currentRenderVersion) {
+            if (currentRenderVersion !== renderVersion) {
+                return;
+            }
+            rendering = false;
+            hide(loading, true);
+            pagesRegion.classList.remove('is-turning', 'is-turning-forward', 'is-turning-backward');
+            updateStatus();
+            saveProgress(false);
+            prefetchPages();
+            if (pendingPage !== null) {
+                const queued = pendingPage;
+                pendingPage = null;
+                goToPage(queued);
+            }
+        };
+
+        const renderSpread = function() {
+            if (!pdfDocument || rendering) {
+                return;
+            }
+
+            const currentRenderVersion = ++renderVersion;
+            rendering = true;
+            pagesRegion.classList.remove('is-turning-forward', 'is-turning-backward');
+            pagesRegion.classList.add('is-turning', turnDirection === 'backward' ? 'is-turning-backward' : 'is-turning-forward');
+            hide(loading, false);
+            pagesRegion.innerHTML = '';
+
+            const visiblePages = getVisiblePages();
+            if (!visiblePages.length) {
+                finishRender(currentRenderVersion);
+                return;
+            }
+
+            renderPageCanvas(visiblePages[0]).then(function(firstCanvas) {
+                if (currentRenderVersion !== renderVersion) {
+                    return Promise.resolve();
+                }
+
+                pagesRegion.appendChild(createPageNode(firstCanvas, visiblePages[0], 0));
+                let placeholder = null;
+
+                if (!isMobile() && visiblePages.length > 1) {
+                    placeholder = createPlaceholderNode(firstCanvas, 1);
+                    pagesRegion.appendChild(placeholder);
+                } else if (!isMobile() && visiblePages.length === 1) {
+                    const empty = createPlaceholderNode(firstCanvas, 1);
+                    empty.classList.add('is-empty');
+                    pagesRegion.appendChild(empty);
+                }
+
+                hide(loading, true);
+                updateStatus();
+
+                const remaining = visiblePages.slice(1).map(function(num, index) {
+                    const position = index + 1;
+                    return renderPageCanvas(num).then(function(canvas) {
+                        if (currentRenderVersion !== renderVersion) {
+                            return;
+                        }
+                        const node = createPageNode(canvas, num, position);
+                        if (placeholder && placeholder.parentNode) {
+                            placeholder.parentNode.replaceChild(node, placeholder);
+                        } else {
+                            pagesRegion.appendChild(node);
+                        }
+                    });
+                });
+
+                return Promise.all(remaining).then(function() {
+                    finishRender(currentRenderVersion);
+                });
+            }).catch(function(err) {
+                rendering = false;
+                hide(loading, true);
+                pagesRegion.classList.remove('is-turning', 'is-turning-forward', 'is-turning-backward');
+                hide(error, false);
+                Notification.exception(err);
+            });
+        };
+
+        const goToPage = function(num) {
+            if (!pdfDocument) {
+                return;
+            }
+            const previousPage = pageNumber;
+            const safe = Math.max(1, Math.min(pdfDocument.numPages, num));
+            const targetPage = isMobile() ? safe : getSpreadStart(safe);
+            turnDirection = targetPage < previousPage ? 'backward' : 'forward';
+            pageNumber = targetPage;
+            if (rendering) {
+                pendingPage = pageNumber;
+                return;
+            }
+            renderSpread();
+        };
+
+        if (previous) {
+            previous.addEventListener('click', function() {
+                goToPage(pageNumber - (isMobile() ? 1 : 2));
+            });
+        }
+        if (next) {
+            next.addEventListener('click', function() {
+                goToPage(pageNumber + (isMobile() ? 1 : 2));
+            });
+        }
+        if (fullscreen) {
+            fullscreen.addEventListener('click', function() {
+                if (document.fullscreenElement) {
+                    document.exitFullscreen();
+                    return;
+                }
+                if (reader.requestFullscreen) {
+                    reader.requestFullscreen().catch(function() {
+                        reader.classList.add('is-fallback-fullscreen');
+                    });
+                } else {
+                    reader.classList.add('is-fallback-fullscreen');
+                }
+            });
+            document.addEventListener('fullscreenchange', function() {
+                if (!document.fullscreenElement) {
+                    reader.classList.remove('is-fallback-fullscreen');
+                }
+                clearPageCache();
+                window.setTimeout(renderSpread, 160);
+            });
+        }
+
+        stage.addEventListener('touchstart', function(event) {
+            if (!event.touches || event.touches.length !== 1) {
+                return;
+            }
+            touchMoved = false;
+            touchStartX = event.touches[0].clientX;
+            touchStartY = event.touches[0].clientY;
+        }, {passive: true});
+
+        stage.addEventListener('touchmove', function(event) {
+            if (!event.touches || event.touches.length !== 1) {
+                return;
+            }
+            const dx = event.touches[0].clientX - touchStartX;
+            const dy = event.touches[0].clientY - touchStartY;
+            touchMoved = Math.abs(dx) > 20 || Math.abs(dy) > 20;
+        }, {passive: true});
+
+        stage.addEventListener('touchend', function(event) {
+            if (!touchMoved || !pdfDocument) {
+                return;
+            }
+            const changed = event.changedTouches && event.changedTouches[0];
+            if (!changed) {
+                return;
+            }
+            const dx = changed.clientX - touchStartX;
+            const dy = changed.clientY - touchStartY;
+            if (Math.abs(dx) < 60 || Math.abs(dx) < Math.abs(dy) * 1.35) {
+                return;
+            }
+            goToPage(pageNumber + (dx < 0 ? 1 : -1));
+        }, {passive: true});
+
+        window.addEventListener('resize', function() {
+            clearPageCache();
+            window.setTimeout(renderSpread, 120);
+        });
+        window.addEventListener('orientationchange', function() {
+            clearPageCache();
+            window.setTimeout(renderSpread, 280);
+        });
+        window.addEventListener('beforeunload', function() {
+            saveProgress(true);
+        });
+        document.addEventListener('visibilitychange', function() {
+            if (document.hidden) {
+                saveProgress(true);
+            } else {
+                lastTick = Date.now();
+            }
+        });
+
+        hide(loading, false);
+        pdfjsLib.getDocument({url: pdfUrl, withCredentials: true, rangeChunkSize: 262144}).promise.then(function(pdf) {
+            pdfDocument = pdf;
+            pageNumber = Math.min(initialPage, pdfDocument.numPages);
+            if (!isMobile()) {
+                pageNumber = getSpreadStart(pageNumber);
+            }
+            updateStatus();
+            renderSpread();
+        }).catch(function(err) {
+            hide(loading, true);
+            hide(error, false);
+            Notification.exception(err);
+        });
+    };
+
+    const init = function() {
+        const roots = Array.prototype.slice.call(document.querySelectorAll('.mod-videoplayer-book-reader'));
+        if (!roots.length) {
+            return;
+        }
+        loadPdfJs().then(function(pdfjsLib) {
+            roots.forEach(function(root) {
+                initViewer(root, pdfjsLib);
+            });
+        }).catch(function(err) {
+            Notification.exception(err);
+            roots.forEach(function(root) {
+                hide(root.querySelector('[data-region="book-loading"]'), true);
+                hide(root.querySelector('[data-region="book-error"]'), false);
+            });
+        });
+    };
+
+    return {
+        init: init
+    };
+});

--- a/amd/src/bookviewer.js
+++ b/amd/src/bookviewer.js
@@ -20,11 +20,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
     const PREFETCH_DELAY = 80;
     let pdfjsPromise = null;
 
-    /**
-     * Load local PDF.js once.
-     *
-     * @returns {Promise<Object>}
-     */
     const loadPdfJs = function() {
         if (!pdfjsPromise) {
             pdfjsPromise = import(PDFJS_URL).then(function(pdfjsLib) {
@@ -35,46 +30,22 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         return pdfjsPromise;
     };
 
-    /**
-     * Whether current viewport is mobile.
-     *
-     * @returns {boolean}
-     */
     const isMobile = function() {
         return window.matchMedia(MOBILE_QUERY).matches;
     };
 
-    /**
-     * Hide or show a DOM node.
-     *
-     * @param {HTMLElement|null} node
-     * @param {boolean} value
-     * @returns {void}
-     */
     const hide = function(node, value) {
         if (node) {
             node.hidden = value;
         }
     };
 
-    /**
-     * Block unsafe viewer interactions.
-     *
-     * @param {Event} event
-     * @returns {boolean}
-     */
     const block = function(event) {
         event.preventDefault();
         event.stopPropagation();
         return false;
     };
 
-    /**
-     * Apply viewer-level deterrents. Server-side authorization remains mandatory.
-     *
-     * @param {HTMLElement} root
-     * @returns {void}
-     */
     const hardenViewer = function(root) {
         if (root.getAttribute('data-disable-context-menu') !== '1') {
             return;
@@ -90,13 +61,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         }, true);
     };
 
-    /**
-     * Initialise one book viewer.
-     *
-     * @param {HTMLElement} root
-     * @param {Object} pdfjsLib
-     * @returns {void}
-     */
     const initViewer = function(root, pdfjsLib) {
         const pdfUrl = root.getAttribute('data-pdf-url');
         const cmid = parseInt(root.getAttribute('data-cmid'), 10) || 0;
@@ -138,12 +102,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         const pageCache = new Map();
         const renderPromises = new Map();
 
-        /**
-         * Get start page for desktop spread.
-         *
-         * @param {number} num
-         * @returns {number}
-         */
         const getSpreadStart = function(num) {
             if (isMobile()) {
                 return num;
@@ -151,11 +109,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             return num <= 1 ? 1 : (num % 2 === 0 ? num : num - 1);
         };
 
-        /**
-         * Get currently visible pages.
-         *
-         * @returns {number[]}
-         */
         const getVisiblePages = function() {
             if (!pdfDocument) {
                 return [];
@@ -171,21 +124,15 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             return pages;
         };
 
-        /**
-         * Build a cache key tied to layout mode and page width.
-         *
-         * @param {number} pageIndex
-         * @returns {string}
-         */
+        const getPageWidth = function() {
+            const stageWidth = Math.max(stage.clientWidth - (isMobile() ? 24 : 128), 280);
+            return isMobile() ? Math.min(stageWidth, 720) : Math.min(stageWidth / 2, 560);
+        };
+
         const getCacheKey = function(pageIndex) {
             return [isMobile() ? 'm' : 'd', Math.round(getPageWidth()), pageIndex].join(':');
         };
 
-        /**
-         * Limit rendered canvas cache to avoid memory pressure.
-         *
-         * @returns {void}
-         */
         const pruneCache = function() {
             const limit = isMobile() ? MOBILE_CACHE_LIMIT : DESKTOP_CACHE_LIMIT;
             while (pageCache.size > limit) {
@@ -194,21 +141,11 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             }
         };
 
-        /**
-         * Clear cached pages after layout dimension changes.
-         *
-         * @returns {void}
-         */
         const clearPageCache = function() {
             pageCache.clear();
             renderPromises.clear();
         };
 
-        /**
-         * Update page counter and navigation state.
-         *
-         * @returns {void}
-         */
         const updateStatus = function() {
             if (!pdfDocument) {
                 return;
@@ -228,11 +165,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             }
         };
 
-        /**
-         * Current completion percentage.
-         *
-         * @returns {number}
-         */
         const completionPercent = function() {
             if (!pdfDocument || !pdfDocument.numPages) {
                 return 0;
@@ -240,12 +172,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             return Math.min(100, Math.round((pageNumber / pdfDocument.numPages) * 10000) / 100);
         };
 
-        /**
-         * Save reading progress.
-         *
-         * @param {boolean} force
-         * @returns {Promise}
-         */
         const saveProgress = function(force) {
             if (!cmid || !pdfDocument) {
                 return Promise.resolve();
@@ -282,22 +208,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             }).catch(Notification.exception);
         };
 
-        /**
-         * Calculate target page width for current layout.
-         *
-         * @returns {number}
-         */
-        const getPageWidth = function() {
-            const stageWidth = Math.max(stage.clientWidth - (isMobile() ? 24 : 128), 280);
-            return isMobile() ? Math.min(stageWidth, 720) : Math.min(stageWidth / 2, 560);
-        };
-
-        /**
-         * Render one page to canvas with in-memory cache.
-         *
-         * @param {number} pageIndex
-         * @returns {Promise<HTMLCanvasElement>}
-         */
         const renderPageCanvas = function(pageIndex) {
             const cacheKey = getCacheKey(pageIndex);
 
@@ -344,35 +254,23 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             return promise;
         };
 
-        /**
-         * Get neighbor pages to prefetch.
-         *
-         * @returns {number[]}
-         */
         const getPrefetchPages = function() {
             if (!pdfDocument) {
                 return [];
             }
 
             if (isMobile()) {
-                return [pageNumber + 1, pageNumber - 1]
-                    .filter(function(num) {
-                        return num >= 1 && num <= pdfDocument.numPages;
-                    });
+                return [pageNumber + 1, pageNumber - 1].filter(function(num) {
+                    return num >= 1 && num <= pdfDocument.numPages;
+                });
             }
 
             const start = getSpreadStart(pageNumber);
-            return [start + 2, start + 3, start - 1, start - 2]
-                .filter(function(num) {
-                    return num >= 1 && num <= pdfDocument.numPages;
-                });
+            return [start + 2, start + 3, start - 1, start - 2].filter(function(num) {
+                return num >= 1 && num <= pdfDocument.numPages;
+            });
         };
 
-        /**
-         * Prefetch neighbor pages after visible pages are ready.
-         *
-         * @returns {void}
-         */
         const prefetchPages = function() {
             window.setTimeout(function() {
                 getPrefetchPages().forEach(function(num) {
@@ -383,14 +281,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             }, PREFETCH_DELAY);
         };
 
-        /**
-         * Build one page node with book-side classes.
-         *
-         * @param {HTMLCanvasElement} canvas
-         * @param {number} pageIndex
-         * @param {number} position
-         * @returns {HTMLElement}
-         */
         const createPageNode = function(canvas, pageIndex, position) {
             const pageNode = document.createElement('div');
             pageNode.className = 'mod-videoplayer-book-page';
@@ -413,11 +303,34 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             return pageNode;
         };
 
-        /**
-         * Render current spread or mobile page.
-         *
-         * @returns {void}
-         */
+        const createPlaceholderNode = function(referenceCanvas, position) {
+            const pageNode = document.createElement('div');
+            const side = position === 0 ? 'left' : 'right';
+            pageNode.className = 'mod-videoplayer-book-page mod-videoplayer-book-page-' + side + ' is-page-loading';
+            if (referenceCanvas) {
+                pageNode.style.width = referenceCanvas.style.width;
+                pageNode.style.height = referenceCanvas.style.height;
+            }
+            return pageNode;
+        };
+
+        const finishRender = function(currentRenderVersion) {
+            if (currentRenderVersion !== renderVersion) {
+                return;
+            }
+            rendering = false;
+            hide(loading, true);
+            pagesRegion.classList.remove('is-turning', 'is-turning-forward', 'is-turning-backward');
+            updateStatus();
+            saveProgress(false);
+            prefetchPages();
+            if (pendingPage !== null) {
+                const queued = pendingPage;
+                pendingPage = null;
+                goToPage(queued);
+            }
+        };
+
         const renderSpread = function() {
             if (!pdfDocument || rendering) {
                 return;
@@ -431,35 +344,49 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             pagesRegion.innerHTML = '';
 
             const visiblePages = getVisiblePages();
-            const renderers = visiblePages.map(function(num, position) {
-                return renderPageCanvas(num).then(function(canvas) {
-                    if (currentRenderVersion !== renderVersion) {
-                        return;
-                    }
-                    pagesRegion.appendChild(createPageNode(canvas, num, position));
-                });
-            });
+            if (!visiblePages.length) {
+                finishRender(currentRenderVersion);
+                return;
+            }
 
-            Promise.all(renderers).then(function() {
+            renderPageCanvas(visiblePages[0]).then(function(firstCanvas) {
                 if (currentRenderVersion !== renderVersion) {
-                    return;
+                    return Promise.resolve();
                 }
-                if (!isMobile() && visiblePages.length === 1) {
-                    const empty = document.createElement('div');
-                    empty.className = 'mod-videoplayer-book-page mod-videoplayer-book-page-right is-empty';
+
+                pagesRegion.appendChild(createPageNode(firstCanvas, visiblePages[0], 0));
+                let placeholder = null;
+
+                if (!isMobile() && visiblePages.length > 1) {
+                    placeholder = createPlaceholderNode(firstCanvas, 1);
+                    pagesRegion.appendChild(placeholder);
+                } else if (!isMobile() && visiblePages.length === 1) {
+                    const empty = createPlaceholderNode(firstCanvas, 1);
+                    empty.classList.add('is-empty');
                     pagesRegion.appendChild(empty);
                 }
-                rendering = false;
+
                 hide(loading, true);
-                pagesRegion.classList.remove('is-turning', 'is-turning-forward', 'is-turning-backward');
                 updateStatus();
-                saveProgress(false);
-                prefetchPages();
-                if (pendingPage !== null) {
-                    const queued = pendingPage;
-                    pendingPage = null;
-                    goToPage(queued);
-                }
+
+                const remaining = visiblePages.slice(1).map(function(num, index) {
+                    const position = index + 1;
+                    return renderPageCanvas(num).then(function(canvas) {
+                        if (currentRenderVersion !== renderVersion) {
+                            return;
+                        }
+                        const node = createPageNode(canvas, num, position);
+                        if (placeholder && placeholder.parentNode) {
+                            placeholder.parentNode.replaceChild(node, placeholder);
+                        } else {
+                            pagesRegion.appendChild(node);
+                        }
+                    });
+                });
+
+                return Promise.all(remaining).then(function() {
+                    finishRender(currentRenderVersion);
+                });
             }).catch(function(err) {
                 rendering = false;
                 hide(loading, true);
@@ -469,12 +396,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
             });
         };
 
-        /**
-         * Go to target page.
-         *
-         * @param {number} num
-         * @returns {void}
-         */
         const goToPage = function(num) {
             if (!pdfDocument) {
                 return;
@@ -593,11 +514,6 @@ define(['core/ajax', 'core/notification'], function(Ajax, Notification) {
         });
     };
 
-    /**
-     * Initialise all book viewers.
-     *
-     * @returns {void}
-     */
     const init = function() {
         const roots = Array.prototype.slice.call(document.querySelectorAll('.mod-videoplayer-book-reader'));
         if (!roots.length) {

--- a/protected.php
+++ b/protected.php
@@ -31,6 +31,34 @@ function mod_videoplayer_send_private_cache_headers(string $etag = '', int $last
 }
 
 /**
+ * Send a safe cache diagnostic header.
+ *
+ * @param string $status Cache status.
+ * @return void
+ */
+function mod_videoplayer_send_cache_status(string $status): void {
+    header('X-Drive-Resource-Cache: ' . preg_replace('/[^A-Z_-]/', '', strtoupper($status)));
+}
+
+/**
+ * Resolve the physical Moodle File API path for a stored file when available.
+ *
+ * @param stored_file $file Stored file.
+ * @return string|null Absolute path or null when not readable.
+ */
+function mod_videoplayer_get_stored_file_path(stored_file $file): ?string {
+    global $CFG;
+
+    $hash = $file->get_contenthash();
+    if ($hash === '' || strlen($hash) < 4) {
+        return null;
+    }
+
+    $path = $CFG->dataroot . '/filedir/' . substr($hash, 0, 2) . '/' . substr($hash, 2, 2) . '/' . $hash;
+    return is_readable($path) ? $path : null;
+}
+
+/**
  * Send a local file with safe byte-range support.
  *
  * @param string $path Absolute local path.
@@ -38,9 +66,17 @@ function mod_videoplayer_send_private_cache_headers(string $etag = '', int $last
  * @param string $contenttype MIME type.
  * @param string $etag Optional stable entity tag.
  * @param int $lastmodified Optional unix timestamp.
+ * @param string $cachestatus Cache diagnostic status.
  * @return void
  */
-function mod_videoplayer_send_file(string $path, string $filename, string $contenttype, string $etag = '', int $lastmodified = 0): void {
+function mod_videoplayer_send_file(
+    string $path,
+    string $filename,
+    string $contenttype,
+    string $etag = '',
+    int $lastmodified = 0,
+    string $cachestatus = 'LOCAL'
+): void {
     if (!is_readable($path)) {
         throw new moodle_exception('protectedresourceunavailable', 'mod_videoplayer');
     }
@@ -74,6 +110,7 @@ function mod_videoplayer_send_file(string $path, string $filename, string $conte
             http_response_code(416);
             header('Content-Range: bytes */' . $size);
             header('Cache-Control: no-store, no-cache, must-revalidate, no-transform');
+            mod_videoplayer_send_cache_status('RANGE_INVALID');
             die;
         }
         $code = 206;
@@ -88,6 +125,7 @@ function mod_videoplayer_send_file(string $path, string $filename, string $conte
     header('X-Robots-Tag: noindex, nofollow, noarchive');
     header('Accept-Ranges: bytes');
     mod_videoplayer_send_private_cache_headers($etag, $lastmodified);
+    mod_videoplayer_send_cache_status($cachestatus);
     header('Content-Length: ' . $length);
     header('Vary: Range');
     if ($code === 206) {
@@ -122,12 +160,14 @@ function mod_videoplayer_send_file(string $path, string $filename, string $conte
  * @return void
  */
 function mod_videoplayer_send_stored_pdf(stored_file $file, string $filename): void {
-    $tmpdir = make_request_directory();
-    $tmppath = $tmpdir . '/' . sha1($file->get_contenthash() . ':' . $file->get_timemodified()) . '.pdf';
+    $path = mod_videoplayer_get_stored_file_path($file);
+    if ($path === null) {
+        $tmpdir = make_request_directory();
+        $path = $tmpdir . '/' . sha1($file->get_contenthash() . ':' . $file->get_timemodified()) . '.pdf';
+        $file->copy_content_to($path);
+    }
 
-    $file->copy_content_to($tmppath);
-
-    $fh = fopen($tmppath, 'rb');
+    $fh = fopen($path, 'rb');
     $header = $fh === false ? '' : fread($fh, 1024);
     if ($fh !== false) {
         fclose($fh);
@@ -137,7 +177,7 @@ function mod_videoplayer_send_stored_pdf(stored_file $file, string $filename): v
         throw new moodle_exception('protectedresourceunavailable', 'mod_videoplayer');
     }
 
-    mod_videoplayer_send_file($tmppath, $filename, 'application/pdf', $file->get_contenthash(), (int)$file->get_timemodified());
+    mod_videoplayer_send_file($path, $filename, 'application/pdf', $file->get_contenthash(), (int)$file->get_timemodified(), 'LOCAL');
 }
 
 /**
@@ -146,9 +186,10 @@ function mod_videoplayer_send_stored_pdf(stored_file $file, string $filename): v
  * @param array $headers Captured upstream headers.
  * @param string $fallbacktype Fallback MIME type.
  * @param string $filename Safe filename.
+ * @param string $cachestatus Cache diagnostic status.
  * @return void
  */
-function mod_videoplayer_send_proxy_headers(array $headers, string $fallbacktype, string $filename): void {
+function mod_videoplayer_send_proxy_headers(array $headers, string $fallbacktype, string $filename, string $cachestatus = 'BYPASS'): void {
     $ispartial = !empty($headers['content-range']) || ((int)($headers['status'] ?? 0) === 206);
     http_response_code($ispartial ? 206 : 200);
     header('Content-Type: ' . ($headers['content-type'] ?? $fallbacktype));
@@ -157,6 +198,7 @@ function mod_videoplayer_send_proxy_headers(array $headers, string $fallbacktype
     header('X-Robots-Tag: noindex, nofollow, noarchive');
     header('Accept-Ranges: bytes');
     mod_videoplayer_send_private_cache_headers();
+    mod_videoplayer_send_cache_status($cachestatus);
     header('Vary: Range');
 
     if (!empty($headers['content-length'])) {
@@ -239,6 +281,7 @@ if ($cachettl <= 0) {
     $cachettl = 86400;
 }
 $cachefile = '';
+$cachestatus = $pdfcache ? 'MISS' : 'BYPASS';
 if ($pdfcache) {
     $cachedir = $CFG->localcachedir . '/mod_videoplayer/pdf';
     if (!is_dir($cachedir)) {
@@ -247,7 +290,7 @@ if ($pdfcache) {
     $cachekey = sha1($fileid . ':' . $type);
     $cachefile = $cachedir . '/' . $cachekey . '.pdf';
     if (is_readable($cachefile) && filemtime($cachefile) + $cachettl > time()) {
-        mod_videoplayer_send_file($cachefile, $filename, $contenttype, $cachekey, filemtime($cachefile) ?: time());
+        mod_videoplayer_send_file($cachefile, $filename, $contenttype, $cachekey, filemtime($cachefile) ?: time(), 'HIT');
     }
 }
 
@@ -300,9 +343,9 @@ $options = [
     CURLOPT_BUFFERSIZE => 262144,
     CURLOPT_HTTPHEADER => $requestheaders,
     CURLOPT_HEADERFUNCTION => $headercallback,
-    CURLOPT_WRITEFUNCTION => function($curl, string $data) use (&$cachehandle, &$headerssent, &$responseheaders, $contenttype, $filename): int {
+    CURLOPT_WRITEFUNCTION => function($curl, string $data) use (&$cachehandle, &$headerssent, &$responseheaders, $contenttype, $filename, $cachestatus): int {
         if (!$headerssent) {
-            mod_videoplayer_send_proxy_headers($responseheaders, $contenttype, $filename);
+            mod_videoplayer_send_proxy_headers($responseheaders, $contenttype, $filename, $cachestatus);
             $headerssent = true;
         }
         if ($cachehandle) {
@@ -323,7 +366,7 @@ $curlcode = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
 curl_close($ch);
 
 if (!$headerssent && $curlcode < 400) {
-    mod_videoplayer_send_proxy_headers($responseheaders, $contenttype, $filename);
+    mod_videoplayer_send_proxy_headers($responseheaders, $contenttype, $filename, $cachestatus);
 }
 
 if ($cachehandle) {

--- a/styles_book_controls.css
+++ b/styles_book_controls.css
@@ -9,6 +9,13 @@
     --drive-book-control-offset: clamp(.85rem, 1.8vw, 1.45rem);
 }
 
+.mod-videoplayer-book-page.is-page-loading {
+    min-height: 16rem;
+    background:
+        linear-gradient(90deg, rgba(255, 255, 255, .8), rgba(226, 232, 240, .65), rgba(255, 255, 255, .8)),
+        #ffffff;
+}
+
 .mod-videoplayer-book-nav {
     z-index: 14;
     opacity: .96;


### PR DESCRIPTION
## Summary

Reduces the time learners spend stuck on `Cargando PDF` and adds safe cache diagnostics for protected streams.

## Changes

- The book viewer now hides the loading overlay as soon as the first visible page is rendered.
- Desktop mode no longer waits for the second page before showing the PDF.
- A lightweight placeholder keeps the second page column stable while it finishes rendering.
- Local Moodle PDFs are streamed directly from Moodle File API storage when possible, avoiding a full temporary copy before delivery.
- Adds `X-Drive-Resource-Cache` response header with safe values such as `LOCAL`, `HIT`, `MISS`, `BYPASS` and `RANGE_INVALID`.
- Updates the production AMD build file.
- Updates changelog documentation.

## Why

Large PDFs can make the viewer appear frozen if the UI waits for both desktop pages to render. Local PDFs also should not be copied to a request temp file before streaming when the protected file already exists in Moodle File API storage.

## Validation

- Purge Moodle caches after deployment.
- Open a large local PDF and confirm the first page appears quickly.
- In DevTools, inspect `protected.php` and check `X-Drive-Resource-Cache`.
- Confirm `Accept-Ranges: bytes` is still present.
- Confirm there is no `Content-Encoding: gzip` for PDF responses.