### PR TITLE
Place mobile book navigation inside PDF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Protected streaming chunk size increased to reduce PHP flush overhead.
 - Book viewer pages now receive left/right page classes and turn-direction classes for realistic desktop transitions.
 - Book viewer controls now place page status at the top center, fullscreen at the top right and previous/next controls at the viewer sides.
+- Mobile book navigation now overlays previous/next controls inside the PDF area instead of placing them below the document.
 - Protected book PDFs now start from page 1 on every page load instead of resuming the last viewed page.
 - Book viewer now hides the loading overlay as soon as the first visible page is rendered instead of waiting for the full desktop spread.
 - Local Moodle PDFs are streamed directly from Moodle File API storage when possible, avoiding a full temporary copy before delivery.

--- a/styles_book_controls.css
+++ b/styles_book_controls.css
@@ -78,6 +78,10 @@
 }
 
 @media (max-width: 767.98px) {
+    .mod-videoplayer-book-stage {
+        padding: .6rem .4rem .85rem;
+    }
+
     .mod-videoplayer-book-topbar {
         top: .65rem;
         right: .65rem;
@@ -98,17 +102,23 @@
     }
 
     .mod-videoplayer-book-nav {
-        bottom: .85rem;
-        width: 3.15rem;
-        height: 3.15rem;
+        top: 50%;
+        bottom: auto;
+        width: 2.75rem;
+        height: 2.75rem;
+        font-size: 2rem;
+        background: rgba(255, 255, 255, .82);
+        box-shadow: 0 10px 24px rgba(15, 23, 42, .2);
+        opacity: .9;
+        transform: translateY(-50%);
     }
 
     .mod-videoplayer-book-nav-prev {
-        left: .85rem;
+        left: .55rem;
     }
 
     .mod-videoplayer-book-nav-next {
-        right: .85rem;
+        right: .55rem;
     }
 
     .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-topbar,
@@ -120,6 +130,18 @@
 
     .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-nav,
     .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-nav {
-        bottom: calc(env(safe-area-inset-bottom, 0px) + .85rem);
+        top: 50%;
+        bottom: auto;
+        transform: translateY(-50%);
+    }
+
+    .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-nav-prev,
+    .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-nav-prev {
+        left: calc(env(safe-area-inset-left, 0px) + .55rem);
+    }
+
+    .mod-videoplayer-book-reader:fullscreen .mod-videoplayer-book-nav-next,
+    .is-fallback-fullscreen.mod-videoplayer-book-reader .mod-videoplayer-book-nav-next {
+        right: calc(env(safe-area-inset-right, 0px) + .55rem);
     }
 }


### PR DESCRIPTION
## Summary

Moves the mobile previous/next navigation controls into the PDF reading area instead of placing them below the document.

## Changes

- Positions mobile previous/next buttons vertically centered over the PDF area.
- Removes the large bottom padding previously reserved for bottom navigation.
- Keeps fullscreen and page counter positions unchanged.
- Applies safe-area aware positioning in fullscreen mode.
- Updates changelog documentation.

## Validation

- Purge Moodle caches after deployment.
- Open a PDF on mobile and confirm previous/next buttons are inside the PDF area.
- Confirm the PDF no longer has excessive bottom spacing for navigation.
- Confirm desktop layout remains unchanged.