### PR TITLE
Add subtle desktop page curvature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Book viewer pages now receive left/right page classes and turn-direction classes for realistic desktop transitions.
 - Book viewer controls now place page status at the top center, fullscreen at the top right and previous/next controls at the viewer sides.
 - Desktop book spine visuals now use a softer premium gradient to avoid dark hard lines between pages.
+- Desktop book pages now use a subtle static curvature effect with perspective, light page bending and inner paper shading.
 - Mobile book navigation now overlays previous/next controls inside the PDF area instead of placing them below the document.
 - Protected book PDFs now start from page 1 on every page load instead of resuming the last viewed page.
 - Book viewer now hides the loading overlay as soon as the first visible page is rendered instead of waiting for the full desktop spread.

--- a/styles_book_controls.css
+++ b/styles_book_controls.css
@@ -25,6 +25,7 @@
 @media (min-width: 768px) {
     .mod-videoplayer-book-pages {
         gap: clamp(.08rem, .28vw, .24rem);
+        perspective: 1800px;
     }
 
     .mod-videoplayer-book-pages::before {
@@ -62,7 +63,14 @@
         opacity: .58;
     }
 
+    .mod-videoplayer-book-page-left,
+    .mod-videoplayer-book-page-right {
+        transform-style: preserve-3d;
+        transition: transform .22s ease, box-shadow .22s ease, filter .22s ease;
+    }
+
     .mod-videoplayer-book-page-left {
+        transform: perspective(1800px) rotateY(1.15deg) translateZ(.01px);
         box-shadow:
             0 16px 38px rgba(15, 23, 42, .105),
             inset -2rem 0 2.6rem rgba(15, 23, 42, .052),
@@ -71,6 +79,7 @@
     }
 
     .mod-videoplayer-book-page-right {
+        transform: perspective(1800px) rotateY(-1.15deg) translateZ(.01px);
         box-shadow:
             0 16px 38px rgba(15, 23, 42, .105),
             inset 2rem 0 2.6rem rgba(15, 23, 42, .052),
@@ -110,6 +119,21 @@
                 transparent 100%);
         box-shadow: none;
         opacity: .55;
+    }
+
+    .mod-videoplayer-book-page-left canvas,
+    .mod-videoplayer-book-page-right canvas {
+        filter: drop-shadow(0 0 0 rgba(15, 23, 42, 0));
+    }
+
+    .mod-videoplayer-book-page-left canvas {
+        transform: translateX(.08rem) scaleX(.997);
+        transform-origin: right center;
+    }
+
+    .mod-videoplayer-book-page-right canvas {
+        transform: translateX(-.08rem) scaleX(.997);
+        transform-origin: left center;
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a subtle desktop-only page curvature effect to the protected book viewer.

## Changes

- Adds perspective to the desktop book spread override.
- Applies a very light static `rotateY` curve to left and right pages.
- Adds small canvas offsets and scale adjustments to simulate paper bending near the gutter.
- Keeps the soft spine gradient from the previous UI refinement.
- Keeps mobile single-page layout unchanged.
- Updates `CHANGELOG.md`.

## Validation

- Purge Moodle caches after deployment.
- Open a PDF on desktop and confirm pages have a slight curvature rather than looking completely flat.
- Confirm the center fold remains soft and not too dark.
- Confirm mobile remains unchanged.