### PR TITLE
Bump plugin version to 1.1.14-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **Drive Resource** are documented in this file.
 
 The internal Moodle component is `mod_videoplayer` for compatibility with previous installations.
 
-## v1.1.0-beta - 2026-06-22
+## v1.1.14-beta - 2026-06-24
 
 ### Added
 
@@ -37,6 +37,7 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 
 ### Changed
 
+- Release metadata bumped to `1.1.14-beta` with Moodle version `2026062410`.
 - `save_progress.php` now delegates business logic to internal services.
 - PDF rendering context now supports both standard and ebook modes.
 - Activity form now supports Google Drive and local protected PDF sources.

--- a/version.php
+++ b/version.php
@@ -3,7 +3,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin = new stdClass();
 $plugin->component = 'mod_videoplayer';
-$plugin->version = 2026062312;
-$plugin->release = '1.1.13-beta';
+$plugin->version = 2026062410;
+$plugin->release = '1.1.14-beta';
 $plugin->requires = 2025041400;
 $plugin->maturity = MATURITY_BETA;


### PR DESCRIPTION
## Summary

Bumps the Drive Resource Moodle plugin version so Moodle detects the latest protected PDF viewer, cache and UI refinements as an upgrade.

## Changes

- Updates `version.php` from `2026062312 / 1.1.13-beta` to `2026062410 / 1.1.14-beta`.
- Updates `CHANGELOG.md` heading and release metadata.

## Deployment

After pulling this update into Moodle:

```bash
php admin/cli/upgrade.php
php admin/cli/purge_caches.php
```

or visit Site administration to complete the Moodle plugin upgrade.