### PR TITLE
Refactor protected stream and PDF cache service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **Drive Resource** are documented in this file.
 
 The internal Moodle component is `mod_videoplayer` for compatibility with previous installations.
 
-## v1.1.14-beta - 2026-06-24
+## v1.1.15-beta - 2026-06-24
 
 ### Added
 
@@ -34,10 +34,14 @@ The internal Moodle component is `mod_videoplayer` for compatibility with previo
 - Dedicated book control placement stylesheet for coherent navigation and fullscreen UI.
 - Protected stream cache diagnostic header `X-Drive-Resource-Cache`.
 - Deterministic server-side cache warming for protected Google Drive PDFs.
+- Internal `mod_videoplayer\local\protected_stream` service for protected byte-range delivery, PDF cache warming and cache cleanup.
 
 ### Changed
 
-- Release metadata bumped to `1.1.14-beta` with Moodle version `2026062410`.
+- Release metadata bumped to `1.1.15-beta` with Moodle version `2026062411`.
+- `protected.php` is now a thin authorised endpoint and delegates streaming, proxying and cache operations to the protected stream service.
+- Google Drive PDF cache warming is reused by both the protected endpoint and the ad-hoc precache task, reducing duplicated cURL/cache code.
+- Scheduled PDF cache cleanup now delegates to the shared protected stream service.
 - `save_progress.php` now delegates business logic to internal services.
 - PDF rendering context now supports both standard and ebook modes.
 - Activity form now supports Google Drive and local protected PDF sources.

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ The internal Moodle component remains `mod_videoplayer` for compatibility with e
 - Publish local protected PDFs stored in Moodle private file storage.
 - Support for videos, PDFs, images, documents, spreadsheets and presentations.
 - Automatic resource type detection for supported Google Drive URLs.
-- Protected `protected.php` delivery endpoint.
+- Protected `protected.php` delivery endpoint backed by a reusable protected stream service.
 - Local PDF.js viewer without CDN.
-- Protected ebook mode with optional local StPageFlip.
+- Protected ebook/book mode with desktop two-page spread and mobile one-page reading.
+- Google Drive PDF cache warming under Moodle local cache.
 - HTML5 video playback with local Plyr assets.
 - Plugin-owned fullscreen viewer for mobile and desktop.
 - Reading progress by page, percentage and active time.
-- Resume reading from the last saved page.
 - Optional watermark deterrent.
 - Optional personal gamification milestones and points.
 - Moodle Completion API integration.
@@ -71,7 +71,7 @@ PageFlip is optional. If it is missing, ebook mode falls back to the protected P
    Site administration > Plugins > Activity modules > Drive Resource
    ```
 
-5. Configure the default tracking and protected mode settings.
+5. Configure the default tracking, protected mode and PDF cache settings.
 
 ## Usage: local protected PDF
 
@@ -117,10 +117,29 @@ require_login()
 context_module
 mod/videoplayer:view
 protected.php
-Moodle File API or secure proxy streaming
+protected_stream service
+Moodle File API, warmed PDF cache or secure proxy streaming
 ```
 
 Browser controls such as disabling right click, hiding download buttons and showing watermarks are deterrents, not DRM.
+
+## Protected PDF cache diagnostics
+
+Protected Google Drive PDFs can be cached under Moodle local cache after Moodle access validation. The response header shows the delivery path:
+
+```text
+X-Drive-Resource-Cache: LOCAL
+X-Drive-Resource-Cache: HIT
+X-Drive-Resource-Cache: WARMED
+X-Drive-Resource-Cache: WARM_FAILED
+X-Drive-Resource-Cache: BYPASS
+```
+
+Cache files are stored outside the web root under:
+
+```text
+$CFG->localcachedir/mod_videoplayer/pdf/
+```
 
 ## Progress tracking
 
@@ -181,7 +200,7 @@ Additional technical documentation is available in the `docs/` directory:
 
 Current development branch:
 
-- Release: `1.1.0-beta`
+- Release: `1.1.15-beta`
 - Component: `mod_videoplayer`
 - Product name: Drive Resource
 - Supported Moodle versions: 4.x and 5.x target

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,9 @@ protected.php
 ↓
 Moodle access checks
 ↓
-Secure proxy or Moodle File API delivery
+protected_stream service
+↓
+Secure proxy, Moodle File API delivery or warmed PDF cache
 ↓
 Local viewer
 ↓
@@ -67,7 +69,27 @@ Authenticated resource endpoint. It validates:
 - `context_module`.
 - `mod/videoplayer:view` capability.
 
-For local PDFs, it uses Moodle File API delivery. For supported Google Drive resources, it streams through a protected proxy.
+After access validation, it delegates byte-range delivery, proxy fallback and PDF cache operations to `classes/local/protected_stream.php`.
+
+### `classes/local/protected_stream.php`
+
+Shared service for protected delivery. It owns:
+
+- local Moodle PDF streaming from private file storage.
+- safe byte-range support for cached/local files.
+- protected proxy fallback for supported Drive resources.
+- Google Drive PDF cache warming.
+- Google Drive confirmation-token retry for cache warming.
+- cache diagnostics through `X-Drive-Resource-Cache`.
+- scheduled cleanup of stale cache, temporary and cookie files.
+
+This service is reused by:
+
+```text
+protected.php
+classes/task/precache_pdf.php
+classes/task/cleanup_pdf_cache.php
+```
 
 ### `view.php`
 
@@ -79,11 +101,37 @@ Main activity page. It:
 - loads the correct AMD viewer.
 - sends initial progress, page and gamification state to the template.
 
+## Protected PDF cache flow
+
+```text
+Google Drive PDF URL
+↓
+protected.php validates Moodle access
+↓
+protected_stream checks local cache
+↓
+HIT: serve PDF from local cache with Range support
+↓
+MISS: warm cache once, validate PDF header, then serve as WARMED
+↓
+WARM_FAILED: fall back to protected upstream proxy
+```
+
+Cache files are stored under Moodle local cache, not under the web root:
+
+```text
+$CFG->localcachedir/mod_videoplayer/pdf/
+```
+
 ## Viewers
 
 ### Standard PDF viewer
 
 `amd/src/pdfviewer.js` renders protected PDFs with local PDF.js.
+
+### Protected book viewer
+
+`amd/src/bookviewer.js` renders the default protected PDF book viewer with local PDF.js. Desktop uses a two-page spread with softened center fold and subtle page curvature. Mobile uses a one-page layout.
 
 ### Ebook viewer
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -46,16 +46,51 @@ thirdpartylibs/                  Local third-party libraries
 
 ## Service layer
 
-Business logic should not be embedded directly in external API classes.
+Business logic should not be embedded directly in external API classes or public endpoints.
 
 Use:
 
 ```text
 classes/local/progress/progress_service.php
 classes/local/gamification/reward_service.php
+classes/local/protected_stream.php
 ```
 
 The external API should validate parameters, context, login and capability, then delegate to services.
+
+`protected.php` must remain a thin authorised endpoint. It should only resolve the Moodle course module, validate `require_login()` and `mod/videoplayer:view`, determine the source/type, then delegate streaming and cache work to `protected_stream`.
+
+## Protected stream service
+
+`classes/local/protected_stream.php` owns all protected resource delivery primitives:
+
+- local Moodle PDF byte-range streaming.
+- safe `Content-Type`, `Content-Length`, `Content-Range`, `Accept-Ranges` and cache headers.
+- `X-Drive-Resource-Cache` diagnostics.
+- Google Drive PDF cache key generation.
+- cache freshness checks.
+- Google Drive PDF cache warming with confirmation-token fallback.
+- upstream proxy fallback.
+- scheduled cache cleanup.
+
+Do not duplicate cURL or cache warming logic in tasks or public endpoint scripts. Reuse this service from:
+
+```text
+protected.php
+classes/task/precache_pdf.php
+classes/task/cleanup_pdf_cache.php
+```
+
+Expected cache states:
+
+```text
+LOCAL         Moodle File API PDF served from moodledata/filedir.
+HIT           Existing fresh server-side PDF cache served.
+WARMED        PDF was downloaded to cache and served from cache.
+WARM_FAILED   Cache warm failed; endpoint fell back to upstream proxy.
+BYPASS        Cache not applicable or disabled.
+RANGE_INVALID Invalid client byte range.
+```
 
 ## Progress save flow
 
@@ -118,6 +153,7 @@ Presentation CSS is split by responsibility:
 ```text
 styles.css                         Base plugin styles loaded by Moodle.
 styles_bookviewer.css              Protected book viewer layout and fullscreen navigation.
+styles_book_controls.css           Book controls, soft spine and desktop curvature refinements.
 styles_pdf_overlay.css             PDF.js overlay and canvas behavior.
 styles_pdf_mobile.css              Mobile PDF-specific viewport rules.
 styles_visual_refinements.css      Product-level visual polish for Drive Resource.
@@ -212,3 +248,4 @@ Before release:
 - JavaScript console clean.
 - mobile PDF viewer tested on iOS Safari, Android Chrome and Moodle app WebView.
 - desktop book viewer tested with portrait PDFs and landscape PDFs.
+- `protected.php` kept free of duplicated low-level streaming/cache logic.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,7 @@
 - PHP 8.2 or newer recommended.
 - Local third-party libraries installed under `thirdpartylibs/`.
 - Moodle cron configured.
+- Writable Moodle local cache directory.
 
 ## Installation
 
@@ -77,6 +78,25 @@ If PageFlip is missing, ebook mode falls back to the protected PDF.js canvas vie
 4. Select or auto-detect the resource type.
 5. Save and display.
 
+## Protected PDF cache
+
+Google Drive PDFs can be warmed into Moodle local cache after Moodle access validation. This improves repeated PDF loads while preserving access control.
+
+Cache location:
+
+```text
+$CFG->localcachedir/mod_videoplayer/pdf/
+```
+
+The web server user must be able to write to Moodle local cache. Cached files remain outside the web root and are only served through `protected.php` after `require_login()`, module context and capability checks.
+
+Use browser developer tools to confirm cache behavior:
+
+```text
+X-Drive-Resource-Cache: WARMED
+X-Drive-Resource-Cache: HIT
+```
+
 ## Upgrade notes
 
 The upgrade step `2026062100` adds:
@@ -87,6 +107,8 @@ The upgrade step `2026062100` adds:
 - reading state fields in `videoplayer_views`.
 - `videoplayer_rewards` table.
 
+Release `1.1.15-beta` refactors protected delivery into `classes/local/protected_stream.php` and bumps Moodle plugin version to `2026062411`.
+
 Always test upgrade on a staging Moodle before deploying to production.
 
 ## Post-installation checklist
@@ -95,10 +117,13 @@ Always test upgrade on a staging Moodle before deploying to production.
 - Confirm `thirdpartylibs.xml` is valid.
 - Confirm PDF.js files are present.
 - Confirm PageFlip files are present if ebook mode is required.
+- Confirm `$CFG->localcachedir` is writable.
 - Create a local PDF activity.
+- Create a Google Drive PDF activity.
 - Open as student.
 - Navigate pages.
 - Confirm progress is saved.
+- Confirm `X-Drive-Resource-Cache` shows `WARMED` then `HIT` for Drive PDFs.
 - Confirm completion is marked after the configured percentage.
 - Test backup and restore.
 - Test privacy export/delete.

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,6 +40,21 @@ Google Drive resources should be proxied where supported. The plugin must avoid 
 
 Some Google-controlled embedded viewer elements cannot be removed because of browser cross-origin isolation. The long-term commercial target is to avoid Google Drive viewer UI completely by using Moodle-owned viewers and secure proxy delivery.
 
+## Protected stream service
+
+`protected.php` is intentionally kept as a thin authorised endpoint. Low-level delivery is delegated to `classes/local/protected_stream.php` so the same security behavior is reused by local files, cached PDFs, proxy fallback and cache tasks.
+
+The protected stream service is responsible for:
+
+- safe byte-range delivery from local files.
+- private browser cache headers with `no-transform`.
+- cache diagnostic header sanitisation.
+- Google Drive PDF cache warming with PDF header validation.
+- fallback to upstream proxy when warming fails.
+- cleanup of stale temporary and cookie files.
+
+Cached Google Drive PDFs are stored under `$CFG->localcachedir/mod_videoplayer/pdf/`. They are not public files; every request still passes through Moodle login, module context and capability validation before bytes are sent.
+
 ## Headers and streaming
 
 `protected.php` should keep memory usage low and preserve streaming behavior. The target requirements are:
@@ -51,7 +66,7 @@ Some Google-controlled embedded viewer elements cannot be removed because of bro
 - correct `Content-Length`.
 - no full-file buffering for large files.
 
-Local Moodle stored files should use Moodle's file serving APIs. External resources should stream through cURL or equivalent chunked delivery.
+Local Moodle stored files should use Moodle private file storage and byte-range delivery through the protected stream service. External resources should stream through cURL or equivalent chunked delivery.
 
 ## Privacy
 
@@ -75,6 +90,7 @@ Before release:
 - test teacher access.
 - verify direct `protected.php?id=<cmid>` access requires login.
 - verify local PDF is not accessible from web root.
+- verify cached Google Drive PDFs are not accessible directly from the web.
 - verify no Drive URLs are rendered in HTML templates for protected local mode.
 - verify backup/restore does not leak files across courses.
 - verify privacy export/delete removes reward and progress records.

--- a/version.php
+++ b/version.php
@@ -3,7 +3,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin = new stdClass();
 $plugin->component = 'mod_videoplayer';
-$plugin->version = 2026062410;
-$plugin->release = '1.1.14-beta';
+$plugin->version = 2026062411;
+$plugin->release = '1.1.15-beta';
 $plugin->requires = 2025041400;
 $plugin->maturity = MATURITY_BETA;


### PR DESCRIPTION
## Summary

Refactors Drive Resource protected delivery for Moodle plugin repository readiness.

## Why

Moodle plugin review expects maintainable code, namespaced selectors/classes, no duplicated low-level logic, secure capability checks, documented third-party behavior, Privacy API readiness and Backup/Restore readiness. This change reduces duplicated protected streaming/cache code and keeps `protected.php` as a thin authorised endpoint.

## Changes

- Adds `classes/local/protected_stream.php` as the shared service for:
  - local protected PDF byte-range delivery.
  - safe stream headers.
  - `X-Drive-Resource-Cache` diagnostics.
  - Google Drive PDF cache keying and freshness checks.
  - Google Drive cache warming with confirmation-token retry.
  - protected upstream proxy fallback.
  - cache cleanup.
- Refactors `protected.php` to validate Moodle access and delegate delivery to the service.
- Refactors `classes/task/precache_pdf.php` to reuse the shared cache warmer.
- Refactors `classes/task/cleanup_pdf_cache.php` to reuse the shared cleanup logic.
- Bumps plugin version to `2026062411 / 1.1.15-beta`.
- Updates README, changelog and docs for the new architecture/security model.

## Validation checklist

- Run `php -l protected.php`.
- Run `php -l classes/local/protected_stream.php`.
- Run `php -l classes/task/precache_pdf.php`.
- Run `php -l classes/task/cleanup_pdf_cache.php`.
- Pull into Moodle and run `php admin/cli/upgrade.php`.
- Purge Moodle caches.
- Test local PDF delivery: `X-Drive-Resource-Cache: LOCAL`.
- Test Google Drive PDF first load: `WARMED` or `HIT`.
- Test Google Drive PDF second load: `HIT`.
- Test unsupported cache fallback: `WARM_FAILED` with protected proxy fallback.
- Test video protected proxy still supports Range requests.
- Test scheduled task cleanup with Moodle cron.

## Notes

This PR is intentionally limited to service extraction, duplicated cache cleanup removal and release/documentation updates. It does not change the database schema.